### PR TITLE
builtin for bswap32/bswap64 is not available on GCC 4.0+ it was available in 4.3

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -165,7 +165,7 @@ SWAPU16(uint16_t x)
     return bswap16(x);
 }
 
-#if !defined(__GNUC__) || __GNUC__ < 4
+#if !defined(__GNUC__) || __GNUC__ < 43
 #define bswap32(x) \
        (((x << 24) & 0xff000000) | \
         ((x <<  8) & 0x00ff0000) | \


### PR DESCRIPTION
Hi,

I'm an Engine Yard employee and one of our customers was having a problem getting the ffi gem working on our AppCloud environment. We're using an older gcc and the built in is not available which made me patch your gem to provide it for our customers.

I'm not entirely positive I have the version correct in the macro I changed, however it is working for us properly if you could verify and then merge?

Thank you very much,

Scott M. Likens
