### PR TITLE
Make spec/ffi/strptr_spec.rb pass on Windows

### DIFF
--- a/spec/ffi/strptr_spec.rb
+++ b/spec/ffi/strptr_spec.rb
@@ -17,12 +17,17 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
 
 describe "functions returning :strptr" do
+
   it "can attach function with :strptr return type" do
     lambda do
       m = Module.new do
         extend FFI::Library
         ffi_lib FFI::Library::LIBC
-        attach_function :strdup, [ :string ], :strptr
+        if !FFI::Platform.windows?
+          attach_function :strdup, [ :string ], :strptr
+        else
+          attach_function :_strdup, [ :string ], :strptr
+        end
       end
     end.should_not raise_error
   end
@@ -30,8 +35,15 @@ describe "functions returning :strptr" do
   module StrPtr
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
-    attach_function :strdup, [ :string ], :strptr
     attach_function :free, [ :pointer ], :void
+    if !FFI::Platform.windows?
+      attach_function :strdup, [ :string ], :strptr
+    else
+      attach_function :_strdup, [ :string ], :strptr
+      class << self
+        alias :strdup :_strdup
+      end
+    end
   end
 
   it "should return [ String, Pointer ]" do


### PR DESCRIPTION
`strdup` is `_strdup` in msvcrt
