### PR TITLE
Avoid spurious entries in @vk_map for FFI::Enum.

### DIFF
--- a/lib/ffi/enum.rb
+++ b/lib/ffi/enum.rb
@@ -57,7 +57,6 @@ module FFI
     def initialize(info, tag=nil)
       @tag = tag
       @kv_map = Hash.new
-      @vk_map = Hash.new
       unless info.nil?
         last_cst = nil
         value = 0
@@ -65,16 +64,15 @@ module FFI
           case i
           when Symbol
             @kv_map[i] = value
-            @vk_map[value] = i
             last_cst = i
             value += 1
           when Integer
             @kv_map[last_cst] = i
-            @vk_map[i] = last_cst
             value = i+1
           end
         end
       end
+      @vk_map = Hash[@kv_map.map{|k,v| [v,k]}]
     end
 
     def symbols

--- a/spec/ffi/enum_spec.rb
+++ b/spec/ffi/enum_spec.rb
@@ -196,4 +196,32 @@ describe "All enums" do
     enum[424242].should == :c15
     enum[42424242].should == :c16
   end
+  it "return nil for values that don't have a symbol" do
+    enum = TestEnum3.enum_type(:enum_type1)
+    enum[-1].should == nil
+    enum[4].should == nil
+
+    enum = TestEnum3.enum_type(:enum_type2)
+    enum[0].should == nil
+    enum[41].should == nil
+    enum[46].should == nil
+
+    enum = TestEnum3.enum_type(:enum_type3)
+    enum[0].should == nil
+    enum[41].should == nil
+    enum[44].should == nil
+    enum[4241].should == nil
+    enum[4244].should == nil
+
+    enum = TestEnum3.enum_type(:enum_type4)
+    enum[0].should == nil
+    enum[41].should == nil
+    enum[43].should == nil
+    enum[4241].should == nil
+    enum[4243].should == nil
+    enum[424241].should == nil
+    enum[424243].should == nil
+    enum[42424241].should == nil
+    enum[42424243].should == nil
+  end
 end


### PR DESCRIPTION
This is a fix for issue #98, which I reported earlier. The commit includes tests.
