### PR TITLE
Fix #write_pointer when writing large value

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -243,7 +243,7 @@ get_pointer_value(VALUE value)
     } else if (type == T_NIL) {
         return NULL;
     } else if (type == T_FIXNUM) {
-        return (void *) (uintptr_t) FIX2INT(value);
+        return (void *) (uintptr_t) FIX2ULONG(value);
     } else if (type == T_BIGNUM) {
         return (void *) (uintptr_t) NUM2ULL(value);
     } else if (rb_respond_to(value, id_to_ptr)) {


### PR DESCRIPTION
Error: `write_pointer': integer 10000000000 too big to convert to`int' (RangeError)

The max value of Fixnum is now based on the _long_ type, at least the case for MRI Ruby.

Signed-off-by: Shin Yee shinyee@speedgocomputing.com
