### PR TITLE
Mingw Compilation Broken

### DIFF
--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -143,7 +143,7 @@ prep_trampoline(void* ctx, void* code, Closure* closure, char* errmsg, size_t er
 }
 
 
-static int
+static long
 trampoline_size(void)
 {
     return sizeof(METHOD_CLOSURE);


### PR DESCRIPTION
This patch fixes the following compilation error on MinGW (gcc 3.4.5):

compiling MethodHandle.c
MethodHandle.c:148: error: conflicting types for 'trampoline_size'
MethodHandle.c:70: error: previous declaration of 'trampoline_size' was here
MethodHandle.c:148: error: conflicting types for 'trampoline_size'
MethodHandle.c:70: error: previous declaration of 'trampoline_size' was here
MethodHandle.c:70: warning: 'trampoline_size' declared `static' but never defined
make: **\* [MethodHandle.o] Error 1

Thanks - Charlie
