### PR TITLE
Heap Corruption

### DIFF
--- a/ext/ffi_c/ClosurePool.c
+++ b/ext/ffi_c/ClosurePool.c
@@ -103,7 +103,7 @@ cleanup_closure_pool(ClosurePool* pool)
         free(memory);
         memory = next;
     }
-    free(pool);
+    xfree(pool);
 }
 
 void


### PR DESCRIPTION
Pool is allocated using ruby's xalloc method but is the destroyed via free.  That means it could be freed by a different runtime library on windows, which is a big no-no and causes a heap corruption error on msvc debug builds.  pool should instead be freed using ruby's xfree method.
