### PR TITLE
Fix endianess check to work on mingw and msvc.

### DIFF
--- a/ext/ffi_c/endian.h
+++ b/ext/ffi_c/endian.h
@@ -33,7 +33,7 @@
 # endif
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 # define LITTLE_ENDIAN 1234
 # define BIG_ENDIAN 4321
 # define BYTE_ORDER LITTLE_ENDIAN


### PR DESCRIPTION
I thought this was working before, but if I compile with mingw I get the error:
# error "Cannot determine the endian-ness of this platform"

This changes the check I added for MSVC to just check for windows, so includes mingw.  Note is probably not 100% correct since windows in theory used to run on alpha and ppc (neither supported for a long time) and will on arm (what's the endianess of that platform?).  But I think this does the trick for now.
