### PR TITLE
Add some error messages to extconf.rb and fail if dependencies are not found

### DIFF
--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -14,11 +14,16 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
       of the following options:
 
       --with-ffi_c-dir=/path/to/ffi
-      --with-ffi_c-lib=/path/to/ffi/include
+      --with-ffi_c-include=/path/to/ffi/include
     EOL
     exit 1
   end
-  
+
+  if RbConfig::CONFIG['host_os'].match(/mswin/i)
+    find_header("stdbool.h", "./msvc")
+    find_header("sys/param.h", "./msvc")
+  end
+
   # We need at least ffi_call and ffi_prep_closure
   libffi_ok = have_library("ffi", "ffi_call", [ "ffi.h" ]) ||
               have_library("libffi", "ffi_call", [ "ffi.h" ])


### PR DESCRIPTION
Not a very important patch, but when things weren't compiling for me on mingw it was a bit confusing because extconf.rb finished, but actually didn't find ffi.h and thus make couldn't compile the code.

So this patch adds hard-fails and a bit more explanation of what went wrong and what to do about it.  See what you think.
