### PR TITLE
AutoPointer#free

### DIFF
--- a/lib/ffi/autopointer.rb
+++ b/lib/ffi/autopointer.rb
@@ -84,11 +84,12 @@ module FFI
 
       def free
         raise RuntimeError.new("pointer already freed") unless @ptr
+        @proc.release(@ptr)
         @autorelease = false
         @ptr = nil
         @proc = nil
       end
-      
+
       def autorelease=(autorelease)
         raise RuntimeError.new("pointer already freed") unless @ptr
         @autorelease = autorelease


### PR DESCRIPTION
Unless I'm missing something, AutoPointer#free not only doesn't free the underlying memory, it prevents the GC finalizer from doing it.  See http://groups.google.com/group/ruby-ffi/browse_thread/thread/26f391cf81cb27df for more info.

Thanks - Charlie
