### PR TITLE
Libtest Threading Fix

### DIFF
--- a/libtest/FunctionTest.c
+++ b/libtest/FunctionTest.c
@@ -18,14 +18,13 @@
  * version 3 along with this work.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <unistd.h>
-
-#ifdef __WIN32__
+#ifdef _WIN32
 #include <windows.h>
 #define sleep(x) Sleep(x)
 #endif
 
-#ifndef __WIN32__
+#ifndef _WIN32
+#include <unistd.h>
 #include <pthread.h>
 #endif
 
@@ -60,7 +59,7 @@ static void* asyncThreadCall(void *data)
 
 void testAsyncCallback(void (*fn)(int), int value)
 {
-#ifndef __WIN32__
+#ifndef _WIN32
     pthread_t t;
     struct async_data d;
     d.fn = fn;


### PR DESCRIPTION
Attached are the changes I made to testThreadedClosureVrV so that windows actually uses thread (as discussed earlier today).

I compiled this with VC and MinGW.  Note I did not test it - since I couldn't actually see any spec that call it. If you point me in the right direction, I'm happy to see if this actually works.

I did have to change the return type of threadVrV to make MinGW happy (VC didn't like the void pointer either but did compile it).  I didn't test on Linux/OSX, so you'll want to verify these changes.
