### PR TITLE
Fix an error on ruby-head (2.0.0dev)

### DIFF
--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -20,6 +20,8 @@
 #
 
 require 'rbconfig'
+require 'ffi_c'
+
 module FFI
   class PlatformError < LoadError; end
 


### PR DESCRIPTION
```
/home/meh/.rvm/gems/ruby-head/gems/ffi-1.0.9/lib/ffi/platform.rb:44:in `<module:Platform>': uninitialized constant FFI::Platform::CPU (NameError)
        from /home/meh/.rvm/gems/ruby-head/gems/ffi-1.0.9/lib/ffi/platform.rb:26:in `<module:FFI>'
        from /home/meh/.rvm/gems/ruby-head/gems/ffi-1.0.9/lib/ffi/platform.rb:23:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/require-extra-0.0.2/lib/require/on.rb:30:in `call'
        from /home/meh/.rvm/gems/ruby-head/gems/require-extra-0.0.2/lib/require/on.rb:30:in `block in <module:Kernel>'
        from /home/meh/.rvm/gems/ruby-head/gems/refining-0.0.5.2/lib/refining.rb:59:in `block (2 levels) in refine_method'
        from /home/meh/.rvm/gems/ruby-head/gems/ffi-1.0.9/lib/ffi/ffi.rb:20:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/require-extra-0.0.2/lib/require/on.rb:30:in `call'
        from /home/meh/.rvm/gems/ruby-head/gems/require-extra-0.0.2/lib/require/on.rb:30:in `block in <module:Kernel>'
        from /home/meh/.rvm/gems/ruby-head/gems/refining-0.0.5.2/lib/refining.rb:59:in `block (2 levels) in refine_method'
        from /home/meh/.rvm/gems/ruby-head/gems/ffi-1.0.9/lib/ffi.rb:11:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/require-extra-0.0.2/lib/require/on.rb:30:in `call'
        from /home/meh/.rvm/gems/ruby-head/gems/require-extra-0.0.2/lib/require/on.rb:30:in `block in <module:Kernel>'
        from /home/meh/.rvm/gems/ruby-head/gems/refining-0.0.5.2/lib/refining.rb:59:in `block (2 levels) in refine_method'
        from /home/meh/.rvm/gems/ruby-head/gems/x11-0.0.1a2/lib/X11/extensions.rb:33:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/x11-0.0.1a2/lib/X11/Xatom.rb:29:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/x11-0.0.1a2/lib/X11/X.rb:29:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/x11-0.0.1a2/lib/X11/Xlib.rb:29:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/meh/.rvm/gems/ruby-head/gems/x11-0.0.1a2/lib/X11/simple.rb:29:in `<top (required)>'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:59:in `require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:59:in `rescue in require'
        from /home/meh/.rvm/rubies/ruby-head/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
        from /home/meh/bin/rtile:3:in `<main>'
```

```
> ruby -v
ruby 2.0.0dev (2011-10-19 trunk 33484) [x86_64-linux]
```

There's probably a cleaner way, but well, this fixes it :P
