### PR TITLE
Fix warnings in FFI::Library#function_names

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -136,8 +136,10 @@ module FFI
     #
     # @param [Symbol] convention one of +:default+, +:stdcall+
     # @return [Symbol] the new calling convention
-    def ffi_convention(convention)
-      @ffi_convention = convention
+    def ffi_convention(convention = nil)
+      @ffi_convention ||= :default
+      @ffi_convention = convention if convention
+      @ffi_convention
     end
 
     # @see #ffi_lib
@@ -212,7 +214,7 @@ module FFI
       # Convert :foo to the native type
       arg_types.map! { |e| find_type(e) }
       options = {
-        :convention => defined?(@ffi_convention) ? @ffi_convention : :default,
+        :convention => ffi_convention,
         :type_map => defined?(@ffi_typedefs) ? @ffi_typedefs : nil,
         :blocking => defined?(@blocking) && @blocking,
         :enums => defined?(@ffi_enums) ? @ffi_enums : nil,
@@ -262,7 +264,7 @@ module FFI
     #   windows api, although using, doesn't have decorated names.
     def function_names(name, arg_types)
       result = [name.to_s]
-      if @ffi_convention == :stdcall
+      if ffi_convention == :stdcall
         # Get the size of each parameter
         size = arg_types.inject(0) do |mem, arg|
           mem + arg.size
@@ -360,7 +362,7 @@ code
       end
 
       options = Hash.new
-      options[:convention] = defined?(@ffi_convention) ? @ffi_convention : :default
+      options[:convention] = ffi_convention
       options[:enums] = @ffi_enums if defined?(@ffi_enums)
       cb = FFI::CallbackInfo.new(find_type(ret), params.map { |e| find_type(e) }, options)
 

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -16,6 +16,24 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
 describe "Library" do
+  describe "#ffi_convention" do
+    it "defaults to :default" do
+      Module.new do
+        extend FFI::Library
+        ffi_convention.should == :default
+      end
+    end
+
+    it "should be settable" do
+      Module.new do
+        extend FFI::Library
+
+        ffi_convention.should == :default
+        ffi_convention :stdcall
+        ffi_convention.should == :stdcall
+      end
+    end
+  end
 
   unless Config::CONFIG['target_os'] =~ /mswin|mingw/
     it "attach_function with no library specified" do


### PR DESCRIPTION
Currently, [FFI::Library#function_names](https://github.com/ffi/ffi/blob/8e86ddbc78b552b11877dca9ee85e99d0fc87ee3/lib/ffi/library.rb#L265) throws a warning if you have not explicitly defined `ffi_convention`. This warning is thrown every time you call [FFI::Library#attach_function](https://github.com/ffi/ffi/blob/8e86ddbc78b552b11877dca9ee85e99d0fc87ee3/lib/ffi/library.rb#L230).

Now, since this check is done at two more places, I figured it’d be a good idea to have an accessor that defaults to the current default (`:default`) value. Using this accessor would avoid the warnings, and also avoid the need to check for `defined?(@ffi_convention)` all the time.
