### PR TITLE
Configure will fail if the srcdir has a space in it

### DIFF
--- a/ext/ffi_c/libffi/configure
+++ b/ext/ffi_c/libffi/configure
@@ -2264,7 +2264,7 @@ test -n "$target_alias" &&
   program_prefix=${target_alias}-
 target_alias=${target_alias-$host_alias}
 
-. ${srcdir}/configure.host
+. "${srcdir}"/configure.host
 
 am__api_version='1.11'
 


### PR DESCRIPTION
This fixes that by putting the srcdir in quotes.
