### PR TITLE
Use RbConfig instead of deprecated Config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,19 +14,19 @@ require 'rbconfig'
 
 load 'tasks/setup.rb'
 
-LIBEXT = case RbConfig::CONFIG['host_os'].downcase
+LIBEXT = case Config::CONFIG['host_os'].downcase
   when /darwin/
     "dylib"
   when /mswin|mingw/
     "dll"
   else
-    RbConfig::CONFIG['DLEXT']
+    Config::CONFIG['DLEXT']
   end
 
-CPU = case RbConfig::CONFIG['host_cpu'].downcase
+CPU = case Config::CONFIG['host_cpu'].downcase
   when /i[3456]86/
     # Darwin always reports i686, even when running in 64bit mode
-    if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
+    if Config::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
       "x86_64"
     else
       "i386"
@@ -42,10 +42,10 @@ CPU = case RbConfig::CONFIG['host_cpu'].downcase
     "powerpc"
 
   else
-    RbConfig::CONFIG['host_cpu']
+    Config::CONFIG['host_cpu']
   end
 
-OS = case RbConfig::CONFIG['host_os'].downcase
+OS = case Config::CONFIG['host_os'].downcase
   when /linux/
     "linux"
   when /darwin/
@@ -59,16 +59,16 @@ OS = case RbConfig::CONFIG['host_os'].downcase
   when /mswin|mingw/
     "win32"
   else
-    RbConfig::CONFIG['host_os'].downcase
+    Config::CONFIG['host_os'].downcase
   end
 
-CC=ENV['CC'] || RbConfig::CONFIG['CC'] || "gcc"
+CC=ENV['CC'] || Config::CONFIG['CC'] || "gcc"
 
 GMAKE = system('which gmake >/dev/null') && 'gmake' || 'make'
 
 LIBTEST = "build/libtest.#{LIBEXT}"
 BUILD_DIR = "build"
-BUILD_EXT_DIR = File.join(BUILD_DIR, "#{RbConfig::CONFIG['arch']}", 'ffi_c', RUBY_VERSION)
+BUILD_EXT_DIR = File.join(BUILD_DIR, "#{Config::CONFIG['arch']}", 'ffi_c', RUBY_VERSION)
 
 # Project general information
 PROJ.name = 'ffi'
@@ -146,7 +146,7 @@ task :install => 'gem:install'
 desc "Clean all built files"
 task :distclean => :clobber do
   FileUtils.rm_rf('build')
-  FileUtils.rm_rf(Dir["lib/**/ffi_c.#{RbConfig::CONFIG['DLEXT']}"])
+  FileUtils.rm_rf(Dir["lib/**/ffi_c.#{Config::CONFIG['DLEXT']}"])
   FileUtils.rm_rf('lib/1.8')
   FileUtils.rm_rf('lib/1.9')
   FileUtils.rm_rf('lib/ffi/types.conf')

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -29,24 +29,24 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
 
   create_header
   
-  $CFLAGS << " -mwin32 " if RbConfig::CONFIG['host_os'] =~ /cygwin/
-  $LOCAL_LIBS << " ./libffi/.libs/libffi_convenience.lib" if RbConfig::CONFIG['host_os'] =~ /mswin/
+  $CFLAGS << " -mwin32 " if Config::CONFIG['host_os'] =~ /cygwin/
+  $LOCAL_LIBS << " ./libffi/.libs/libffi_convenience.lib" if Config::CONFIG['host_os'] =~ /mswin/
   #$CFLAGS << " -Werror -Wunused -Wformat -Wimplicit -Wreturn-type "
-  if (ENV['CC'] || RbConfig::MAKEFILE_CONFIG['CC'])  =~ /gcc/
+  if (ENV['CC'] || Config::MAKEFILE_CONFIG['CC'])  =~ /gcc/
 #    $CFLAGS << " -Wno-declaration-after-statement "
   end
   
   create_makefile("ffi_c")
   unless libffi_ok
     File.open("Makefile", "a") do |mf|
-      mf.puts "LIBFFI_HOST=--host=#{RbConfig::CONFIG['host_alias']}" if RbConfig::CONFIG.has_key?("host_alias")
-      if RbConfig::CONFIG['host_os'].downcase =~ /darwin/
+      mf.puts "LIBFFI_HOST=--host=#{Config::CONFIG['host_alias']}" if Config::CONFIG.has_key?("host_alias")
+      if Config::CONFIG['host_os'].downcase =~ /darwin/
         mf.puts "include ${srcdir}/libffi.darwin.mk"
-      elsif RbConfig::CONFIG['host_os'].downcase =~ /bsd/
+      elsif Config::CONFIG['host_os'].downcase =~ /bsd/
         mf.puts '.include "${srcdir}/libffi.bsd.mk"'
-      elsif RbConfig::CONFIG['host_os'].downcase =~ /mswin64/
+      elsif Config::CONFIG['host_os'].downcase =~ /mswin64/
         mf.puts '!include $(srcdir)/libffi.vc64.mk'
-      elsif RbConfig::CONFIG['host_os'].downcase =~ /mswin32/
+      elsif Config::CONFIG['host_os'].downcase =~ /mswin32/
         mf.puts '!include $(srcdir)/libffi.vc.mk'
       else
         mf.puts "include ${srcdir}/libffi.mk"

--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -26,7 +26,7 @@ module FFI
   # This module defines different constants and class methods to play with
   # various platforms.
   module Platform
-    OS = case RbConfig::CONFIG['host_os'].downcase
+    OS = case Config::CONFIG['host_os'].downcase
     when /linux/
       "linux"
     when /darwin/
@@ -40,7 +40,7 @@ module FFI
     when /mingw|mswin/
       "windows"
     else
-      RbConfig::CONFIG['host_os'].downcase
+      Config::CONFIG['host_os'].downcase
     end
 
     ARCH = case CPU.downcase
@@ -51,7 +51,7 @@ module FFI
     when /ppc|powerpc/
       "powerpc"
     else
-      RbConfig::CONFIG['host_cpu']
+      Config::CONFIG['host_cpu']
     end
 
     private

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -35,7 +35,7 @@ describe "Library" do
     end
   end
 
-  unless RbConfig::CONFIG['target_os'] =~ /mswin|mingw/
+  unless Config::CONFIG['target_os'] =~ /mswin|mingw/
     it "attach_function with no library specified" do
       lambda {
         Module.new do |m|

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -21,7 +21,7 @@ if RUBY_PLATFORM =~/java/
   $:.reject! { |p| p == libdir }
 else
   $:.unshift File.join(File.dirname(__FILE__), "..", "..", "lib"),
-    File.join(File.dirname(__FILE__), "..", "..", "build", "#{RbConfig::CONFIG['host_cpu''arch']}", "ffi_c", RUBY_VERSION)
+    File.join(File.dirname(__FILE__), "..", "..", "build", "#{Config::CONFIG['host_cpu''arch']}", "ffi_c", RUBY_VERSION)
 end
 # puts "loadpath=#{$:.join(':')}"
 require "ffi"


### PR DESCRIPTION
RbConfig works on Ruby >=1.8.5 (i.e. everywhere), and Config is deprecated
as of Ruby 1.9.3.

---

I couldn't figure out how to compile and test. I only did `find -type f | xargs perl -pi -e 's/RbConfig/Config/g'`, so I'm not expecting any issues, but could you please run the test suite before pushing this, just to be sure?
