### PR TITLE
Allow comparison of FFI::Pointer::NULL with nil

### DIFF
--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -292,6 +292,9 @@ ptr_equals(VALUE self, VALUE other)
     
     Data_Get_Struct(self, Pointer, ptr);
 
+    if (NIL_P(other))
+	return ptr->memory.address == NULL ? Qtrue : Qfalse;
+
     return ptr->memory.address == POINTER(other)->address ? Qtrue : Qfalse;
 }
 

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -105,6 +105,9 @@ describe "Pointer" do
       lambda { null_ptr.read_int }.should raise_error(FFI::NullPointerError)
       lambda { null_ptr.write_int(0xff1) }.should raise_error(FFI::NullPointerError)
     end
+    it 'returns true when compared with nil' do
+      (FFI::Pointer::NULL == nil).should be_true
+    end
   end
 
 end


### PR DESCRIPTION
'FFI::Pointer::NULL == nil' currently raises an ArgumentError. Trunk versions of Rubinius and JRuby return 'true' when comparing a NULL pointer with nil. This patch fixes the issue with the ArgumentError and introduces the same behavior that JRuby and Rubinius ffi support. Also added a spec for this.

Without this, trying to be platform-independent, I have to use awkward comparisons like 

``` ruby
if nil == ptr || ptr.null?
  #do something about it
end
```

instead of a simple 'if ptr == nil'.

Regards,
Martin
