### PR TITLE
VC++ doesn't support strtold.

### DIFF
--- a/ext/ffi_c/LongDouble.h
+++ b/ext/ffi_c/LongDouble.h
@@ -27,6 +27,9 @@
 extern "C" {
 #endif
 
+#ifdef _MSC_VER
+#define strtold strtod
+#endif
 
 extern VALUE rbffi_longdouble_new(long double ld);
 extern long double rbffi_num2longdouble(VALUE value);


### PR DESCRIPTION
According to wikipedia, VC does not have a separate long double type, instead it just uses a double.  Thus strtold is not supported.
