### PR TITLE
Use the appropriate runtime library on Windows. This is necessary for ve...

### DIFF
--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -90,7 +90,7 @@ module FFI
     end
 
     LIBC = if IS_WINDOWS
-      "msvcrt.dll"
+      RbConfig::CONFIG['RUBY_SO_NAME'].split('-')[-2] + '.dll'
     elsif IS_GNU
       GNU_LIBC
     else


### PR DESCRIPTION
...rsions of Ruby built with MSVC++, where the runtime is actually msvcr100.dll, for example.
