### PR TITLE
add blksize_t types for 32 and 64bit linux

### DIFF
--- a/lib/ffi/platform/arm-linux/types.conf
+++ b/lib/ffi/platform/arm-linux/types.conf
@@ -16,6 +16,7 @@ rbx.platform.typedef.__dev_t = ulong_long
 rbx.platform.typedef.__uid_t = uint
 rbx.platform.typedef.__gid_t = uint
 rbx.platform.typedef.__in_addr_t = uint
+rbx.platform.typedef.__in_port_t = ushort
 rbx.platform.typedef.__ino_t = ulong
 rbx.platform.typedef.__ino64_t = ulong_long
 rbx.platform.typedef.__mode_t = uint

--- a/lib/ffi/platform/i386-linux/types.conf
+++ b/lib/ffi/platform/i386-linux/types.conf
@@ -59,6 +59,7 @@ rbx.platform.typedef.ino_t = ulong_long
 rbx.platform.typedef.dev_t = ulong_long
 rbx.platform.typedef.gid_t = uint
 rbx.platform.typedef.in_addr_t = uint
+rbx.platform.typedef.in_port_t = ushort
 rbx.platform.typedef.mode_t = uint
 rbx.platform.typedef.nlink_t = uint
 rbx.platform.typedef.uid_t = uint

--- a/lib/ffi/platform/ia64-linux/types.conf
+++ b/lib/ffi/platform/ia64-linux/types.conf
@@ -16,6 +16,7 @@ rbx.platform.typedef.__dev_t = ulong
 rbx.platform.typedef.__uid_t = uint
 rbx.platform.typedef.__gid_t = uint
 rbx.platform.typedef.__in_addr_t = uint
+rbx.platform.typedef.__in_port_t = ushort
 rbx.platform.typedef.__ino_t = ulong
 rbx.platform.typedef.__ino64_t = ulong
 rbx.platform.typedef.__mode_t = uint

--- a/lib/ffi/platform/x86_64-linux/types.conf
+++ b/lib/ffi/platform/x86_64-linux/types.conf
@@ -58,6 +58,7 @@ rbx.platform.typedef.ino_t = ulong
 rbx.platform.typedef.dev_t = ulong
 rbx.platform.typedef.gid_t = uint
 rbx.platform.typedef.in_addr_t = uint
+rbx.platform.typedef.in_port_t = ushort
 rbx.platform.typedef.mode_t = uint
 rbx.platform.typedef.nlink_t = ulong
 rbx.platform.typedef.uid_t = uint


### PR DESCRIPTION
Currently trying to use a shared library that refers blksize_t on ubuntu gives an error like so - http://travis-ci.org/#!/avalanche123/uvrb/jobs/1437498/L5198. This enables the type on 32 and 64 bit linuxes
