### PR TITLE
fixes issue when compiling with whatever flags ruby 1.9.3 provides that ...

### DIFF
--- a/ext/ffi_c/StructLayout.c
+++ b/ext/ffi_c/StructLayout.c
@@ -168,7 +168,7 @@ static VALUE
 struct_field_put(VALUE self, VALUE pointer, VALUE value)
 {
     StructField* f;
-    
+
     Data_Get_Struct(self, StructField, f);
     if (f->memoryOp == NULL) {
         rb_raise(rb_eArgError, "put not supported for %s", rb_obj_classname(f->rbType));
@@ -184,7 +184,7 @@ static VALUE
 function_field_get(VALUE self, VALUE pointer)
 {
     StructField* f;
-    
+
     Data_Get_Struct(self, StructField, f);
 
     return rbffi_Function_NewInstance(f->rbType, (*rbffi_AbstractMemoryOps.pointer->get)(MEMORY(pointer), f->offset));
@@ -240,11 +240,11 @@ array_field_put(VALUE self, VALUE pointer, VALUE value)
 {
     StructField* f;
     ArrayType* array;
-    
+
 
     Data_Get_Struct(self, StructField, f);
     Data_Get_Struct(f->rbType, ArrayType, array);
-    
+
     if (isCharArray(array) && rb_obj_is_instance_of(value, rb_cString)) {
         VALUE argv[2];
 
@@ -360,7 +360,8 @@ struct_layout_initialize(VALUE self, VALUE field_names, VALUE fields, VALUE size
             rb_raise(rb_eTypeError, "wrong type for field %d.", i);
         }
 
-        Data_Get_Struct(rbField, StructField, field = layout->fields[i]);
+        field = layout->fields[i];
+        Data_Get_Struct(rbField, StructField, field);
 
         if (field->type == NULL || field->type->ffiType == NULL) {
             rb_raise(rb_eRuntimeError, "type of field %d not supported", i);
@@ -451,7 +452,7 @@ rbffi_StructLayout_Init(VALUE moduleFFI)
 {
     rbffi_StructLayoutClass = rb_define_class_under(moduleFFI, "StructLayout", rbffi_TypeClass);
     rb_global_variable(&rbffi_StructLayoutClass);
-    
+
     rbffi_StructLayoutFieldClass = rb_define_class_under(rbffi_StructLayoutClass, "Field", rb_cObject);
     rb_global_variable(&rbffi_StructLayoutFieldClass);
 


### PR DESCRIPTION
...ruby < 1.9.3 doesn't

Fixes

```
Installing ffi (0.6.3) with native extensions Unfortunately, a fatal error has occurred. Please report this error to the Bundler issue tracker at https://github.com/carlhuda/bundler/issues so that we can fix it. Thanks!
/home/vagrant/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/installer.rb:552:in `rescue in block in build_extensions': ERROR: Failed to build gem native extension. (Gem::Installer::ExtensionBuildError)

        /home/vagrant/.rvm/rubies/ruby-1.9.3-p125/bin/ruby extconf.rb 
extconf.rb:6: Use RbConfig instead of obsolete and deprecated Config.
checking for ffi_call() in -lffi... yes
checking for ffi_prep_closure()... yes
checking for ffi_raw_call()... yes
checking for ffi_prep_raw_closure()... yes
checking for rb_thread_blocking_region()... yes
creating extconf.h
creating Makefile

make
compiling ClosurePool.c
compiling StructLayout.c
StructLayout.c: In function ‘struct_layout_initialize’:
StructLayout.c:363: error: lvalue required as left operand of assignment
make: *** [StructLayout.o] Error 1
```

virtualbox or vagrant depends on this particular version?
