### PR TITLE
MemoryPointer.from_string calls to_str (closes #215)

### DIFF
--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -144,8 +144,9 @@ memptr_mark(Pointer* ptr)
 }
 
 static VALUE
-memptr_s_from_string(VALUE klass, VALUE s)
+memptr_s_from_string(VALUE klass, VALUE to_str)
 {
+    VALUE s = StringValue(to_str);
     VALUE args[] = { INT2FIX(1), LONG2NUM(RSTRING_LEN(s) + 1), Qfalse };
     VALUE obj = rb_class_new_instance(3, args, klass);
     rb_funcall(obj, rb_intern("put_string"), 2, INT2FIX(0), s);

--- a/spec/ffi/rbx/memory_pointer_spec.rb
+++ b/spec/ffi/rbx/memory_pointer_spec.rb
@@ -16,6 +16,10 @@ describe "MemoryPointer" do
     m.type_size.should eq 1
   end
 
+  it "does not make a pointer from non-strings" do
+    expect { FFI::MemoryPointer.from_string(nil) }.to raise_error(TypeError)
+  end
+
   it "makes a pointer from a string with multibyte characters" do
     m = FFI::MemoryPointer.from_string("ぱんだ")
     m.total.should eq 10


### PR DESCRIPTION
Being able to call to_str on an object means that object is intended
to be able to be used as a string for all intents and purposes. This
should make it safe for _our_ purposes.

See issue #215 for original issue.
