### PR TITLE
Fix call to variadic functions

### DIFF
--- a/ext/ffi_c/Variadic.c
+++ b/ext/ffi_c/Variadic.c
@@ -219,7 +219,7 @@ variadic_invoke(VALUE self, VALUE parameterTypes, VALUE parameterValues)
     if (ffiReturnType == NULL) {
         rb_raise(rb_eArgError, "Invalid return type");
     }
-    ffiStatus = ffi_prep_cif(&cif, invoker->abi, paramCount, ffiReturnType, ffiParamTypes);
+    ffiStatus = ffi_prep_cif_var(&cif, invoker->abi, paramCount, paramCount, ffiReturnType, ffiParamTypes);
     switch (ffiStatus) {
         case FFI_BAD_ABI:
             rb_raise(rb_eArgError, "Invalid ABI specified");


### PR DESCRIPTION
This changes the call to ffi_prep_cif into a call to ffi_prep_cif_var,
which is the improved libffi API for calling variadic functions.

Calling variadic functions with floating point arguments with
ffi_prep_cif currently only breaks in armhf, but could also break on
other architectures where the ABI for variadic functions is different
from what you would expect.

For more information, please check the following message to the libffi
development mailing list:
http://permalink.gmane.org/gmane.comp.lib.ffi.general/277
