### PR TITLE
Fix for issue #228. Install of ffi 1.1.5 failed on Cygwin 1.7.3 Windows x64

### DIFF
--- a/ext/ffi_c/LongDouble.c
+++ b/ext/ffi_c/LongDouble.c
@@ -3,6 +3,12 @@
 #include <stdarg.h>
 #include <float.h>
 
+#if defined (__CYGWIN__) || defined(__INTERIX)
+
+#define strtold(str, endptr)    ((long double)strtod((str),(endptr)))
+
+#endif /* defined (__CYGWIN__) */
+
 static VALUE rb_cBigDecimal = Qnil;
 static VALUE bigdecimal_load(VALUE unused);
 static VALUE bigdecimal_failed(VALUE value);


### PR DESCRIPTION
Added define for absent function at Cygwin platform.
