### PR TITLE
Use Rubinius GC api for forcing GC

### DIFF
--- a/spec/ffi/managed_struct_spec.rb
+++ b/spec/ffi/managed_struct_spec.rb
@@ -39,11 +39,7 @@ describe "Managed Struct" do
         loop = 5
         while loop > 0 && @@count < count
           loop -= 1
-          if RUBY_PLATFORM =~ /java/
-            java.lang.System.gc
-          else
-            GC.start
-          end
+          TestLibrary.force_gc
           sleep 0.05 if @@count < count
         end
       end

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -118,11 +118,7 @@ describe "AutoPointer" do
       loop = 5
       while @@count < count && loop > 0
         loop -= 1
-        if RUBY_PLATFORM =~ /java/
-          java.lang.System.gc
-        else
-          GC.start
-        end
+        TestLibrary.force_gc
         sleep 0.05 unless @@count == count
       end
       @@count = 0

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -17,6 +17,15 @@ require "ffi"
 
 module TestLibrary
   PATH = "build/libtest.#{FFI::Platform::LIBSUFFIX}"
+  def self.force_gc
+    if RUBY_PLATFORM =~ /java/
+      java.lang.System.gc
+    elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
+      GC.run(true)
+    else
+      GC.start
+    end
+  end
 end
 module LibTest
   extend FFI::Library


### PR DESCRIPTION
Looked like the FFI gem mainly depended on finalizer ordering which was causing most of the issues. Since those have been fixed, with this change the FFI specs are green on Rubinius.
