### PR TITLE
Fix example that is invalid in rdoc

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -90,7 +90,7 @@ module FFI
     # @return [Array]
     # Read an array of +type+ of length +length+.
     # @example
-    #  ptr.write_array_of_type(TYPE_UINT8, :get_uint8, 4) # -> [1, 2, 3, 4]
+    #  ptr.read_array_of_type(TYPE_UINT8, :get_uint8, 4) # -> [1, 2, 3, 4]
     def read_array_of_type(type, reader, length)
       ary = []
       size = FFI.type_size(type)


### PR DESCRIPTION
This example should call read_array_of_type and is calling write_array_of_type. I guess was copied over from the other method example but name of method was not changed by mistake.
