### PR TITLE
Add x64-mingw32 target to win32 cross compilation tasks.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -200,15 +200,16 @@ if USE_RAKE_COMPILER
     # ext.lib_dir = BUILD_DIR                                 # put binaries into this folder.
     ext.tmp_dir = BUILD_DIR                                   # temporary folder used during compilation.
     ext.cross_compile = true                                  # enable cross compilation (requires cross compile toolchain)
-    ext.cross_platform = 'i386-mingw32'                       # forces the Windows platform instead of the default one
+    ext.cross_platform = ['i386-mingw32', 'x64-mingw32']      # forces the Windows platform instead of the default one
   end
 
-  task 'copy:ffi_c:i386-mingw32:1.9.3' do |t|
-    sh "i686-w64-mingw32-strip -S lib/1.9/ffi_c.so"
-  end
-  
-  task 'copy:ffi_c:i386-mingw32:2.0.0' do |t|
-    sh "i686-w64-mingw32-strip -S lib/2.0/ffi_c.so"
+  ENV['RUBY_CC_VERSION'].to_s.split(':').each do |ruby_version|
+    task "copy:ffi_c:i386-mingw32:#{ruby_version}" do |t|
+      sh "i686-w64-mingw32-strip -S build/i386-mingw32/stage/lib/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so"
+    end
+    task "copy:ffi_c:x64-mingw32:#{ruby_version}" do |t|
+      sh "x86_64-w64-mingw32-strip -S build/x64-mingw32/stage/lib/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so"
+    end
   end
 end
 

--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://wiki.github.com/ffi/ffi'
   s.summary = 'Ruby FFI'
   s.description = 'Ruby FFI library'
-  s.files = %w(ffi.gemspec History.txt LICENSE COPYING COPYING.LESSER README.md Rakefile) + Dir.glob("{ext,gen,lib,spec,libtest}/**/*").reject { |f| f =~ /lib\/1\.[89]/}
+  s.files = %w(ffi.gemspec History.txt LICENSE COPYING COPYING.LESSER README.md Rakefile) + Dir.glob("{ext,gen,lib,spec,libtest}/**/*").reject { |f| f =~ /lib\/[12]\.[089]/}
   s.extensions << 'ext/ffi_c/extconf.rb'
   s.has_rdoc = false
   s.rdoc_options = %w[--exclude=ext/ffi_c/.*\.o$ --exclude=ffi_c\.(bundle|so)$]


### PR DESCRIPTION
Just in case https://github.com/luislavena/rake-compiler/pull/74 gets merged, attached you can find a patch for x64 cross compilation of ffi.
