### PR TITLE
Fix compile error for cygwin1.7.18, without -mwin32 option.

### DIFF
--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -36,7 +36,6 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
 
   create_header
   
-  $CFLAGS << " -mwin32 " if RbConfig::CONFIG['host_os'] =~ /cygwin/
   $LOCAL_LIBS << " ./libffi/.libs/libffi_convenience.lib" if RbConfig::CONFIG['host_os'] =~ /mswin/
 
   create_makefile("ffi_c")


### PR DESCRIPTION
#263 occurd in CYGWIN_NT-6.1-WOW64 1.7.18(0.263/5/3) 2013-04-19 10:39 i686 Cygwin.

I think -mwin32 option isn't need in this version.
I remove and test. It's all green.
