### PR TITLE
Fix path in strip task for x64-mingw32 build.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -197,7 +197,7 @@ if USE_RAKE_COMPILER
 
     task "copy:ffi_c:x64-mingw32:#{ruby_version}" do |t|
       if File.exists?("#{BUILD_DIR}/x64-mingw32/stage/lib/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so")
-        sh "x86_64-w64-mingw32-strip -S #{dir}/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so"
+        sh "x86_64-w64-mingw32-strip -S #{BUILD_DIR}/x64-mingw32/stage/lib/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so"
       end
     end
   end


### PR DESCRIPTION
Running `rake gem:win32` with rake-compiler-0.9.0.pre.1 failed with undefined variable `dir`.
