### PR TITLE
Add x86_64-cygwin types.conf.

### DIFF
--- a/lib/ffi/platform/x86_64-cygwin/types.conf
+++ b/lib/ffi/platform/x86_64-cygwin/types.conf
@@ -1,0 +1,3 @@
+rbx.platform.typedef.size_t = uint64
+rbx.platform.typedef.ptrdiff_t = int64
+rbx.platform.typedef.ssize_t = int64


### PR DESCRIPTION
This fixes the `rake test` on Cygwin x86_64.
