### PR TITLE
Improve loading of linker script .so files

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -135,8 +135,8 @@ module FFI
 
             rescue Exception => ex
               ldscript = false
-              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*invalid ELF header/
-                if File.read($1) =~ /GROUP *\( *([^ \)]+) *\)/
+              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short)/
+                if File.read($1) =~ /(?:GROUP|INPUT) *\( *([^ \)]+)/
                   libname = $1
                   ldscript = true
                 end


### PR DESCRIPTION
On my debian system the ncurses .so files in /usr/lib/i386-linux-gnu/ are GNU ld linker scripts that use the INPUT directive. For example:

$ cat /usr/lib/i386-linux-gnu/libncursesw.so
INPUT(libncursesw.so.5 -ltinfo)

As well on my system, dlopen was returning "file too short" instead of "invalid ELF header". This fix should correct both issues. The original fix for this issue seems to have been inspired by a previous fix for the same issue in the Glasgow Haskel Compiler by Howard B. Golden:

http://ghc.haskell.org/trac/ghc/ticket/2615

It seems like the original fix by Howard and as implemented by Andreas Niederl handles the error 'invalid ELF header' but not 'file too short'. Later Howard B. Golden improved the fix to handle the 'file too short' error as well:

https://mail.python.org/pipermail/python-dev/2011-September/113568.html

This change uses the same corrected Regex that Howard added.
