### PR TITLE
Reject .so and .bundle files in gem.

### DIFF
--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://wiki.github.com/ffi/ffi'
   s.summary = 'Ruby FFI'
   s.description = 'Ruby FFI library'
-  s.files = %w(ffi.gemspec History.txt LICENSE COPYING README.md Rakefile) + Dir.glob("{ext,gen,lib,spec,libtest}/**/*").reject { |f| f =~ /lib\/[12]\.[089]/}
+  s.files = %w(ffi.gemspec History.txt LICENSE COPYING README.md Rakefile) + Dir.glob("{ext,gen,lib,spec,libtest}/**/*").reject { |f| f =~ /(lib\/[12]\.[089]|\.so|\.bundle)/}
   s.extensions << 'ext/ffi_c/extconf.rb'
   s.has_rdoc = false
   s.rdoc_options = %w[--exclude=ext/ffi_c/.*\.o$ --exclude=ffi_c\.(bundle|so)$]


### PR DESCRIPTION
According to https://github.com/ffi/ffi/issues/292#issuecomment-27396461 I made this quick fix to reject `.so` and `.bundle` files in packaged gem to avoid #292.
