### PR TITLE
Fix test case so that it works on x86-mingw32 platform.

### DIFF
--- a/spec/ffi/typedef_spec.rb
+++ b/spec/ffi/typedef_spec.rb
@@ -70,8 +70,13 @@ describe "Custom type definitions" do
       Module.new do
         extend FFI::Library
         ffi_lib "c"
-        # read(2) is a standard UNIX function
-        attach_function :read, [:int, :pointer, :size_t], :ssize_t
+        if FFI::Platform.windows?
+          # _read() is a function of msvcrt.dll
+          attach_function :_read, [:int, :pointer, :uint], :int
+        else
+          # read(2) is a standard UNIX function
+          attach_function :read, [:int, :pointer, :size_t], :ssize_t
+        end
       end
     end.should_not raise_error
   end


### PR DESCRIPTION
Currently the specs fail with one failure on x86-mingw32:

```
  1) Custom type definitions detects the correct type for size_t
     Failure/Error: lambda do
       expected no Exception, got #<FFI::NotFoundError: Function 'read' not found in [msvcrt.dll]> with backtrace:
         # ./lib/ffi/library.rb:261:in `attach_function'
         # ./spec/ffi/typedef_spec.rb:74:in `block (4 levels) in <top (required)>'
         # ./spec/ffi/typedef_spec.rb:70:in `initialize'
         # ./spec/ffi/typedef_spec.rb:70:in `new'
         # ./spec/ffi/typedef_spec.rb:70:in `block (3 levels) in <top (required)>'
         # ./spec/ffi/typedef_spec.rb:69:in `block (2 levels) in <top (required)>'
     # ./spec/ffi/typedef_spec.rb:69:in `block (2 levels) in <top (required)>'
```

The patch uses `Platform.windows?`, which means MSVC++ and Mingw32 platforms (but not Cygwin). On these two platforms `_read()` can be used, instead.
