### PR TITLE
Fix invalid memory access caused by double dereferencing mapped types in...

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -759,8 +759,8 @@ invoke_callback(void* data)
         VALUE rbParamType = rb_ary_entry(cbInfo->rbParameterTypes, i);
 
         if (unlikely(paramType->nativeType == NATIVE_MAPPED)) {
-            paramType = ((MappedType *) paramType)->type;
             rbParamType = ((MappedType *) paramType)->rbType;
+            paramType = ((MappedType *) paramType)->type;
         }
 
         switch (paramType->nativeType) {


### PR DESCRIPTION
... callback parameters.

This is triggered in callback_spec in "struct by reference argument".

Valgrind stacktrace:

```
==22636== Invalid read of size 8
==22636==    at 0xBF964B3: invoke_callback (Function.c:763)
==22636==    by 0x4EA66BD: rb_rescue2 (eval.c:714)
==22636==    by 0xBF9638A: callback_with_gvl (Function.c:737)
==22636==    by 0xBF96054: callback_invoke (Function.c:475)
==22636==    by 0xC1B18CA: ffi_closure_unix64_inner (in /usr/lib/x86_64-linux-gnu/libffi.so.6.0.1)
==22636==    by 0xC1B1C43: ffi_closure_unix64 (in /usr/lib/x86_64-linux-gnu/libffi.so.6.0.1)
==22636==    by 0xC1B1ADB: ffi_call_unix64 (in /usr/lib/x86_64-linux-gnu/libffi.so.6.0.1)
==22636==    by 0xC1B140B: ffi_call (in /usr/lib/x86_64-linux-gnu/libffi.so.6.0.1)
==22636==    by 0xBF9FB43: rbffi_CallFunction (Call.c:378)
==22636==    by 0xBF9FFD5: custom_trampoline (MethodHandle.c:232)
==22636==    by 0x4FCE5DE: vm_call_cfunc_with_frame (vm_insnhelper.c:1469)
==22636==    by 0x4FDC4FC: vm_call_method (vm_insnhelper.c:1559)
==22636==  Address 0xbb9fc30 is 8 bytes after a block of size 24 alloc'd
==22636==    at 0x4C2A2DB: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22636==    by 0x4EC06E7: vm_xmalloc (gc.c:3519)
==22636==    by 0xBF9B2EB: builtin_type_new (Type.c:151)
==22636==    by 0xBF9C95E: rbffi_Type_Init (Type.c:389)
==22636==    by 0xBF94A7B: Init_ffi_c (ffi.c:75)
==22636==    by 0x4E6048C: dln_load (dln.c:1354)
==22636==    by 0x4FDEE59: rb_vm_call_cfunc (vm.c:1530)
==22636==    by 0x4EAA960: rb_require_safe (load.c:963)
==22636==    by 0x4FCE5DE: vm_call_cfunc_with_frame (vm_insnhelper.c:1469)
==22636==    by 0x4FD3089: vm_exec_core (insns.def:1017)
==22636==    by 0x4FD74A9: vm_exec (vm.c:1201)
==22636==    by 0x4FDE7ED: rb_iseq_eval (vm.c:1436)
```
