### PR TITLE
Fix stdcall ABI call convention.

### DIFF
--- a/ext/ffi_c/FunctionInfo.c
+++ b/ext/ffi_c/FunctionInfo.c
@@ -119,7 +119,7 @@ fntype_initialize(int argc, VALUE* argv, VALUE self)
     ffi_status status;
     VALUE rbReturnType = Qnil, rbParamTypes = Qnil, rbOptions = Qnil;
     VALUE rbEnums = Qnil, rbConvention = Qnil, rbBlocking = Qnil;
-#if defined(_WIN32) || defined(__WIN32__)
+#if defined(X86_WIN32)
     VALUE rbConventionStr;
 #endif
     int i, nargs;
@@ -181,7 +181,7 @@ fntype_initialize(int argc, VALUE* argv, VALUE self)
     fnInfo->ffiReturnType = fnInfo->returnType->ffiType;
 
 
-#if (defined(_WIN32) || defined(__WIN32__)) && defined(FFI_STDCALL) 
+#if defined(X86_WIN32)
     rbConventionStr = (rbConvention != Qnil) ? rb_funcall2(rbConvention, rb_intern("to_s"), 0, NULL) : Qnil;
     fnInfo->abi = (rbConventionStr != Qnil && strcmp(StringValueCStr(rbConventionStr), "stdcall") == 0)
             ? FFI_STDCALL : FFI_DEFAULT_ABI;

--- a/ext/ffi_c/Variadic.c
+++ b/ext/ffi_c/Variadic.c
@@ -103,7 +103,7 @@ variadic_initialize(VALUE self, VALUE rbFunction, VALUE rbParameterTypes, VALUE 
     VALUE retval = Qnil;
     VALUE convention = Qnil;
     VALUE fixed = Qnil;
-#if defined(_WIN32) || defined(__WIN32__)
+#if defined(X86_WIN32)
     VALUE rbConventionStr;
 #endif
     int i;
@@ -116,7 +116,7 @@ variadic_initialize(VALUE self, VALUE rbFunction, VALUE rbParameterTypes, VALUE 
     invoker->rbAddress = rbFunction;
     invoker->function = rbffi_AbstractMemory_Cast(rbFunction, rbffi_PointerClass)->address;
 
-#if (defined(_WIN32) || defined(__WIN32__)) && defined(FFI_STDCALL)
+#if defined(X86_WIN32)
     rbConventionStr = rb_funcall2(convention, rb_intern("to_s"), 0, NULL);
     invoker->abi = (RTEST(convention) && strcmp(StringValueCStr(rbConventionStr), "stdcall") == 0)
             ? FFI_STDCALL : FFI_DEFAULT_ABI;

--- a/libtest/ClosureTest.c
+++ b/libtest/ClosureTest.c
@@ -50,6 +50,21 @@ P(D, double);
 P(P, const void*);
 P(UL, unsigned long);
 
+#if defined(_WIN32) && !defined(_WIN64)
+bool __stdcall testClosureStdcall(long *a1, void __stdcall(*closure)(void *, long), long a2) { \
+    void* sp_pre;
+    void* sp_post;
+
+    asm volatile (" movl %%esp,%0" : "=g" (sp_pre));
+    (*closure)(a1, a2);
+    asm volatile (" movl %%esp,%0" : "=g" (sp_post));
+
+    /* %esp before pushing parameters on the stack and after the call returns
+     * should be equal, if both sides respects the stdcall convention */
+    return sp_pre == sp_post;
+}
+#endif
+
 void testOptionalClosureBrV(void (*closure)(char), char a1)
 {
     if (closure) {


### PR DESCRIPTION
FFI_STDCALL is no define, so we can not use the preprocessor to check for it's presense. The result is, that stdcall is currently never used. This patch uses libffi's defines in order to enable the stdcall option.

This fixes issue #302 and adds a test case for stdcall callbacks.

This issue was resolved before in commit 1dcb818 (resulting to issue #213) but commit 32b1a4e broke it again.
