### PR TITLE
Fix compuation of bytes stored on the stack for :stdcall, used for function decoration.

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -279,11 +279,11 @@ module FFI
       if ffi_convention == :stdcall
         # Get the size of each parameter
         size = arg_types.inject(0) do |mem, arg|
-          mem + arg.size
+          size = arg.size
+          # The size must be a multiple of 4
+          size += (4 - size) % 4
+          mem + size
         end
-
-        # Next, the size must be a multiple of 4
-        size += (4 - size) % 4
 
         result << "_#{name.to_s}@#{size}" # win32
         result << "#{name.to_s}@#{size}" # win64

--- a/libtest/FunctionTest.c
+++ b/libtest/FunctionTest.c
@@ -56,3 +56,15 @@ void testAsyncCallback(void (*fn)(int), int value)
     (*fn)(value);
 #endif
 } 
+
+#if defined(_WIN32) && !defined(_WIN64)
+struct StructUCDP {
+  unsigned char a1;
+  double a2;
+  void *a3;
+};
+
+void __stdcall testStdcallManyParams(long *a1, char a2, short int a3, int a4, __int64 a5,
+            struct StructUCDP a6, struct StructUCDP *a7, float a8, double a9) {
+}
+#endif

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -24,6 +24,29 @@ describe "Library" do
     end
   end
 
+  if FFI::Platform::OS =~ /windows|cygwin/ && FFI::Platform::ARCH == 'i386'
+    module LibTestStdcall
+      extend FFI::Library
+      ffi_lib TestLibrary::PATH
+      ffi_convention :stdcall
+
+      class StructUCDP < FFI::Struct
+        layout :a1, :uchar,
+          :a2, :double,
+          :a3, :pointer
+      end
+
+      attach_function :testStdcallManyParams, [ :pointer, :int8, :int16, :int32, :int64,
+              StructUCDP.by_value, StructUCDP.by_ref, :float, :double ], :void
+    end
+
+    it "adds stdcall decoration: testStdcallManyParams@64" do
+      s = LibTestStdcall::StructUCDP.new
+      po = FFI::MemoryPointer.new :long
+      LibTestStdcall.testStdcallManyParams po, 1, 2, 3, 4, s, s, 1.0, 2.0
+    end
+  end
+
   describe "ffi_lib" do
     it "empty name list should raise error" do
       lambda {


### PR DESCRIPTION
Each single parameter must be widened to 32-bit: http://msdn.microsoft.com/en-us/library/984x0h58.aspx
