### PR TITLE
Fix return type of callback function to rb_thread_call_with_gvl().

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -86,7 +86,7 @@ static void function_free(Function *);
 static VALUE function_init(VALUE self, VALUE rbFunctionInfo, VALUE rbProc);
 static void callback_invoke(ffi_cif* cif, void* retval, void** parameters, void* user_data);
 static bool callback_prep(void* ctx, void* code, Closure* closure, char* errmsg, size_t errmsgsize);
-static VALUE callback_with_gvl(void* data);
+static void* callback_with_gvl(void* data);
 static VALUE invoke_callback(void* data);
 static VALUE save_callback_exception(void* data, VALUE exc);
 
@@ -731,10 +731,11 @@ async_cb_call(void *data)
 
 #endif
 
-static VALUE
+static void *
 callback_with_gvl(void* data)
 {
     rb_rescue2(invoke_callback, (VALUE) data, save_callback_exception, (VALUE) data, rb_eException, (VALUE) 0);
+    return NULL;
 }
 
 static VALUE


### PR DESCRIPTION
The return value is not used but caused a compiler warning:

```
  Function.c: In function 'callback_invoke':
  Function.c:479:9: warning: passing argument 1 of 'rb_thread_call_with_gvl' from incompatible pointer type [enabled by default]
  Function.c:102:14: note: expected 'void * (*)(void *)' but argument is of type 'VALUE (*)(void *)'
```

This addresses issue #297.
