### PR TITLE
Fix library loading on FreeBSD systems

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -114,7 +114,7 @@ module FFI
 
             rescue Exception => ex
               ldscript = false
-              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short)/
+              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short|invalid file format)/
                 if File.read($1) =~ /(?:GROUP|INPUT) *\( *([^ \)]+)/
                   libname = $1
                   ldscript = true


### PR DESCRIPTION
Libc does not load on FreeBSD. This updates the regex to detect ld scripts on FreeBSD properly.
