### PR TITLE
Fix FreeBSD 10

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -114,9 +114,9 @@ module FFI
 
             rescue Exception => ex
               ldscript = false
-              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short)/
-                if File.read($1) =~ /(?:GROUP|INPUT) *\( *([^ \)]+)/
-                  libname = $1
+              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short|invalid file format)/
+                if File.read($1) =~ /(?:GROUP|INPUT) *\( *([^\)]+)/
+                  libname = $1.split(' ')[0]
                   ldscript = true
                 end
               end


### PR DESCRIPTION
Fix for FreeBSD 10, the regexp for parsing `ex.message` was lifted from: https://github.com/ffi/ffi/pull/328

That patch didn't quite work, though. This one should.

I did _not_ test this on any other OS (ie. Linux), lacking access to such a system...

This fixes: https://github.com/ffi/ffi/issues/308

For reference, the contents of /usr/lib/libc.so is:

```
/* $FreeBSD: release/10.0.0/lib/libc/libc.ldscript 258398 2013-11-20 20:24:59Z peter $ */
GROUP ( /lib/libc.so.7 /usr/lib/libc_nonshared.a /usr/lib/libssp_nonshared.a )
```
