### PR TITLE
Add failing test for Pointer#write_array_of_type

### DIFF
--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -80,6 +80,11 @@ describe "Pointer" do
       end
     end
     
+    it "#write_array_of_type" do
+      memory = FFI::MemoryPointer.new :pointer, 3
+      memory.write_array_of_type(FFI::TYPE_UINT8, :put_uint8,[1,2,3])
+      #should not throw exception
+    end
   end
 
   describe 'NULL' do


### PR DESCRIPTION
This method fails with an ArgumentException deeper in the stack.

```
Failure/Error: memory.write_array_of_type(FFI::TYPE_UINT8, :put_uint8,[1,2,3])
     ArgumentError:
       wrong number of arguments (1 for 2)
     # ./lib/ffi/pointer.rb:128:in `put_uint8'
     # ./lib/ffi/pointer.rb:128:in `block in write_array_of_type'
     # ./lib/ffi/pointer.rb:127:in `each'
     # ./lib/ffi/pointer.rb:127:in `each_with_index'
     # ./lib/ffi/pointer.rb:127:in `write_array_of_type'
     # ./spec/ffi/pointer_spec.rb:85:in `block (3 levels) in <top (required)>'
```