### PR TITLE
Add ruby 2.1 to the list of cross build ruby versions for Windows.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -151,7 +151,7 @@ task 'spec:specdoc' => TEST_DEPS
 task :default => :specs
 
 task 'gem:win32' do
-  sh("rake cross native gem RUBY_CC_VERSION='1.8.7:1.9.3:2.0.0'") || raise("win32 build failed!")
+  sh("rake cross native gem RUBY_CC_VERSION='1.8.7:1.9.3:2.0.0:2.1.1'") || raise("win32 build failed!")
 end
 
 


### PR DESCRIPTION
@luislavena released the RubyInstaller 2.1.3 for Windows some days ago, which is [not yet covered by the binary ffi gem](https://github.com/ffi/ffi/issues/368), but requires installation as source gem. Fortunately cross build runs fine for all 4 target x86 and 2 x64 versions in my rake-compiler-dev-box.

Unfortunately current rake-compiler requires a 3-part version number (2.1.1), so I set it to the [version that is currently used for the rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box/blob/master/bin/prepare_xrubies#L39) .

@tduehr What do you think - is the current state of the master branch ready to do a release? I'm waiting for the stdcall fixes to be released, too. :yum: 
