### PR TITLE
#360:  Use correct compiler flag when using Solaris Studio.

### DIFF
--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -10,7 +10,13 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   $CFLAGS.gsub!(/[\s+]-ansi/, '')
   $CFLAGS.gsub!(/[\s+]-std=[^\s]+/, '')
   # solaris 10 needs -c99 for <stdbool.h>
-  $CFLAGS << " -std=c99" if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.11)/
+  if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.1[0-2])/
+    if RbConfig::CONFIG['GCC'] != ""
+      $CFLAGS << " -std=c99" 
+    else
+      $CFLAGS << " -xc99" 
+    end
+  end
   
   if ENV['RUBY_CC_VERSION'].nil? && (pkg_config("libffi") ||
      have_header("ffi.h") ||


### PR DESCRIPTION
This will also allow compiler flag to be set for older/newer versions of Solaris.  Admittedly, it is a bit of a preemptive strike for later versions.

This should help with issue #360.
