### PR TITLE
Add FFI::Enum#size

### DIFF
--- a/lib/ffi/enum.rb
+++ b/lib/ffi/enum.rb
@@ -149,6 +149,12 @@ module FFI
       Type::INT
     end
 
+    # Get the size of the enum
+    # @return [Integer]
+    def size
+      native_type.size
+    end
+
     # @param [Symbol, Integer, #to_int] val
     # @param ctx unused
     # @return [Integer] value of a enum symbol


### PR DESCRIPTION
This allows enums to be used directly in calls to FFI::MemoryPointer.new.
While you still can't get the enum back out, you're at least future-proofing
your code against the (admittedly small) possibility that the type of your
enums may change in the future (and FFI adds support for that, such as via
