### PR TITLE
Memory alignment fix for VS2013 x64

### DIFF
--- a/ext/ffi_c/AbstractMemory.h
+++ b/ext/ffi_c/AbstractMemory.h
@@ -165,6 +165,13 @@ get_memory_op(Type* type)
 #define MEMORY_PTR(obj) MEMORY((obj))->address
 #define MEMORY_LEN(obj) MEMORY((obj))->size
 
+/* ensure the memory is aligned on at least a 8 byte boundary */
+#if __x86_64__ || _WIN64 || __ppc64__
+#define MEMORY_ALIGN_MASK 0x7ULL
+#else
+#define MEMORY_ALIGN_MASK 0x7UL
+#endif
+#define MEMORY_ALIGN(p) (((uintptr_t) p + MEMORY_ALIGN_MASK) & (uintptr_t) ~MEMORY_ALIGN_MASK)
 
 
 #ifdef	__cplusplus

--- a/ext/ffi_c/Buffer.c
+++ b/ext/ffi_c/Buffer.c
@@ -114,7 +114,7 @@ buffer_initialize(int argc, VALUE* argv, VALUE self)
         }
 
         /* ensure the memory is aligned on at least a 8 byte boundary */
-        p->memory.address = (void *) (((uintptr_t) p->data.storage + 0x7) & (uintptr_t) ~0x7UL);
+		p->memory.address = (void *) MEMORY_ALIGN(p->data.storage);
     
         if (p->memory.size > 0 && (nargs < 3 || RTEST(rbClear))) {
             memset(p->memory.address, 0, p->memory.size);
@@ -154,7 +154,7 @@ buffer_initialize_copy(VALUE self, VALUE other)
         return Qnil;
     }
     
-    dst->memory.address = (void *) (((uintptr_t) dst->data.storage + 0x7) & (uintptr_t) ~0x7UL);
+	dst->memory.address = (void *) MEMORY_ALIGN(dst->data.storage);
     dst->memory.size = src->size;
     dst->memory.typeSize = src->typeSize;
     

--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -112,7 +112,7 @@ memptr_malloc(VALUE self, long size, long count, bool clear)
     p->memory.typeSize = (int) size;
     p->memory.size = msize;
     /* ensure the memory is aligned on at least a 8 byte boundary */
-    p->memory.address = (char *) (((uintptr_t) p->storage + 0x7) & (uintptr_t) ~0x7UL);;
+	p->memory.address = (char *) MEMORY_ALIGN(p->storage);
     p->allocated = true;
 
     if (clear && p->memory.size > 0) {

--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -183,7 +183,7 @@ ptr_initialize_copy(VALUE self, VALUE other)
     
     dst->allocated = true;
     dst->autorelease = true;
-    dst->memory.address = (void *) (((uintptr_t) dst->storage + 0x7) & (uintptr_t) ~0x7UL);
+	dst->memory.address = (void *) MEMORY_ALIGN(dst->storage);
     dst->memory.size = src->size;
     dst->memory.typeSize = src->typeSize;
     


### PR DESCRIPTION
On Windows x64 compilation with VisualStudio 2013 any call to ffi function ends with segmentation fault.
It's caused by invalid memory alignment. The used mask 0x7UL is 32 bit on this platform, 0x7ULL is required.
