### PR TITLE
Fix compatibility with newer libffi on Windows/MSVC

### DIFF
--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -132,12 +132,6 @@ rbffi_MethodHandle_CodeAddress(MethodHandle* handle)
 #ifndef CUSTOM_TRAMPOLINE
 static void attached_method_invoke(ffi_cif* cif, void* retval, METHOD_PARAMS parameters, void* user_data);
 
-static ffi_type* methodHandleParamTypes[] = {
-    &ffi_type_sint,
-    &ffi_type_pointer,
-    &ffi_type_ulong,
-};
-
 static ffi_cif mh_cif;
 
 static bool
@@ -339,7 +333,12 @@ void
 rbffi_MethodHandle_Init(VALUE module)
 {
 #ifndef CUSTOM_TRAMPOLINE
-    ffi_status ffiStatus;
+    ffi_status ffiStatus;	
+    ffi_type* methodHandleParamTypes[] = {
+        &ffi_type_sint,
+        &ffi_type_pointer,
+        &ffi_type_ulong,
+    };
 #endif
 
     defaultClosurePool = rbffi_ClosurePool_New((int) trampoline_size(), prep_trampoline, NULL);

--- a/ext/ffi_c/StructLayout.c
+++ b/ext/ffi_c/StructLayout.c
@@ -510,8 +510,8 @@ struct_layout_initialize(VALUE self, VALUE fields, VALUE size, VALUE align)
 static VALUE
 struct_layout_union_bang(VALUE self) 
 {
-    static const ffi_type *alignment_types[] = { &ffi_type_sint8, &ffi_type_sint16, &ffi_type_sint32, &ffi_type_sint64,
-                                                 &ffi_type_float, &ffi_type_double, &ffi_type_longdouble, NULL };
+    const ffi_type *alignment_types[] = { &ffi_type_sint8, &ffi_type_sint16, &ffi_type_sint32, &ffi_type_sint64,
+                                          &ffi_type_float, &ffi_type_double, &ffi_type_longdouble, NULL };
     StructLayout* layout;
     ffi_type *t = NULL;
     int count, i;

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -33,10 +33,11 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   $defs << "-DHAVE_EXTCONF_H" if $defs.empty? # needed so create_header works
   $defs << "-DUSE_INTERNAL_LIBFFI" unless libffi_ok
   $defs << "-DRUBY_1_9" if RUBY_VERSION >= "1.9.0"
+  $defs << "-DFFI_BUILDING" if RbConfig::CONFIG['host_os'] =~ /mswin/ # for compatibility with newer libffi
 
   create_header
   
-  $LOCAL_LIBS << " ./libffi/.libs/libffi_convenience.lib" if RbConfig::CONFIG['host_os'] =~ /mswin/
+  $LOCAL_LIBS << " ./libffi/.libs/libffi_convenience.lib" if !libffi_ok && RbConfig::CONFIG['host_os'] =~ /mswin/
 
   create_makefile("ffi_c")
   unless libffi_ok


### PR DESCRIPTION
This allows users to provide their own version of libffi instead of always using the bundled version. Newer libffi also implies linking against a DLL on Windows, but we currently link statically for the extension.