### PR TITLE
Remove unused `hasStruct` from FunctionType

### DIFF
--- a/ext/ffi_c/Function.h
+++ b/ext/ffi_c/Function.h
@@ -69,7 +69,6 @@ struct FunctionType_ {
     VALUE rbEnums;
     bool ignoreErrno;
     bool blocking;
-    bool hasStruct;
 };
 
 extern VALUE rbffi_FunctionTypeClass, rbffi_FunctionClass;

--- a/ext/ffi_c/FunctionInfo.c
+++ b/ext/ffi_c/FunctionInfo.c
@@ -141,7 +141,6 @@ fntype_initialize(int argc, VALUE* argv, VALUE self)
     fnInfo->rbParameterTypes = rb_ary_new2(fnInfo->parameterCount);
     fnInfo->rbEnums = rbEnums;
     fnInfo->blocking = RTEST(rbBlocking);
-    fnInfo->hasStruct = false;
 
     for (i = 0; i < fnInfo->parameterCount; ++i) {
         VALUE entry = rb_ary_entry(rbParamTypes, i);
@@ -157,10 +156,6 @@ fntype_initialize(int argc, VALUE* argv, VALUE self)
             fnInfo->callbackParameters[fnInfo->callbackCount++] = type;
         }
 
-        if (rb_obj_is_kind_of(type, rbffi_StructByValueClass)) {
-            fnInfo->hasStruct = true;
-        }
-
         rb_ary_push(fnInfo->rbParameterTypes, type);
         Data_Get_Struct(type, Type, fnInfo->parameterTypes[i]);
         fnInfo->ffiParameterTypes[i] = fnInfo->parameterTypes[i]->ffiType;
@@ -171,10 +166,6 @@ fntype_initialize(int argc, VALUE* argv, VALUE self)
     if (!RTEST(fnInfo->rbReturnType)) {
         VALUE typeName = rb_funcall2(rbReturnType, rb_intern("inspect"), 0, NULL);
         rb_raise(rb_eTypeError, "Invalid return type (%s)", RSTRING_PTR(typeName));
-    }
-    
-    if (rb_obj_is_kind_of(fnInfo->rbReturnType, rbffi_StructByValueClass)) {
-        fnInfo->hasStruct = true;
     }
 
     Data_Get_Struct(fnInfo->rbReturnType, Type, fnInfo->returnType);


### PR DESCRIPTION
Noticed this while looking at code, `hasStruct` was used before, but there was done some refactoring and it's not used anymore so there's no need for it. All tests does pass.
