### PR TITLE
Fixed the spec for the FFI:Function's :blocking parameter

### DIFF
--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -62,16 +62,16 @@ describe FFI::Function do
     expect(foo.add(10, 10)).to eq(20)
   end
 
-  it 'can wrap a blocking function' do
+  it 'can run multiple blocking functions concurrently' do
     fp = FFI::Function.new(:void, [ :int ], @libtest.find_function('testBlocking'), :blocking => true)
+    time = Time.now
     threads = 10.times.map do |x|
       Thread.new do
-        time = Time.now
-        fp.call(2)
-        expect(Time.now - time).to be > 2
+        fp.call(1)
       end
     end
     threads.each { |t| t.join }
+    expect(Time.now - time).to be < 9
   end
 
   it 'autorelease flag is set to true by default' do


### PR DESCRIPTION
Quick intro: FFI:Function can wrap a C function, and if the `:blocking` parameter is set to true then it should release MRI's global interpreter lock (GIL) when you call the function, allowing multiple blocking functions to run concurrently.

You can tell the old spec was bad because you could remove `:blocking => true` from the spec and it would still pass.  I fixed it so that it actually tests that multiple blocking functions will run concurrently.  If they are not running concurrently, the spec is guaranteed to take at least 10 seconds to finish and it will therefore fail.