### PR TITLE
Fixed the spec for the FFI::Function's :blocking parameter (try #2)

### DIFF
--- a/spec/ffi/fixtures/FunctionTest.c
+++ b/spec/ffi/fixtures/FunctionTest.c
@@ -24,9 +24,46 @@ int testFunctionAdd(int a, int b, int (*f)(int, int))
     return f(a, b);
 };
 
-void testBlocking(int seconds) {
-    sleep(seconds);
-};
+// The first thread that starts running this function will set the
+// flag variable to 1 and then wait for another thread to set it back
+// to 0, which confirms that two copies of the function were running
+// concurrently.  This function returns 0 for success or a non-zero
+// error code from pthreads.
+int testBlocking()
+{
+#ifndef _WIN32
+    static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+    static volatile int flag = 0;
+    int error;
+
+    error = pthread_mutex_lock(&mutex);
+    if (error) { return error; }
+
+    if (flag)
+    {
+        flag = 0;
+    }
+    else
+    {
+        flag = 1;
+
+        while(flag)
+        {
+            error = pthread_mutex_unlock(&mutex);
+            if (error) { return error; }
+
+            usleep(100);
+
+            error = pthread_mutex_lock(&mutex);
+            if (error) { return error; }
+        }
+    }
+
+    error = pthread_mutex_unlock(&mutex);
+    if (error) { return error; }
+#endif
+    return 0;
+}
 
 struct async_data {
     void (*fn)(int);

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -63,15 +63,12 @@ describe FFI::Function do
   end
 
   it 'can wrap a blocking function' do
-    fp = FFI::Function.new(:void, [ :int ], @libtest.find_function('testBlocking'), :blocking => true)
-    threads = 10.times.map do |x|
-      Thread.new do
-        time = Time.now
-        fp.call(2)
-        expect(Time.now - time).to be > 2
-      end
-    end
-    threads.each { |t| t.join }
+    fp = FFI::Function.new(:int, [], @libtest.find_function('testBlocking'), :blocking => true)
+    error2 = nil
+    thread = Thread.new { error2 = fp.call }
+    error1 = fp.call
+    thread.join
+    expect([error1, error2]).to eq [0, 0]
   end
 
   it 'autorelease flag is set to true by default' do


### PR DESCRIPTION
This is my second attempt to fix the spec for the FFI:Function blocking parameter.  For more information, see the first attempt:

https://github.com/ffi/ffi/pull/405

This version passes a message from one thread to another in a way that requires two different threads to be running the C code concurrently.  It is not affected by the speed of the computer it is running on.  (On the WIN32 platform, the test will not test anything, but it should at least pass.  It would be nice to get pthreads working on Windows though.)