### PR TITLE
Anchor ruby version patterns to start of line

### DIFF
--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -1,15 +1,15 @@
 if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   Object.send(:remove_const, :FFI) if defined?(::FFI)
   begin
-    if RUBY_VERSION =~ /1\.8/
+    if RUBY_VERSION =~ /^1\.8/
       require '1.8/ffi_c'
-    elsif RUBY_VERSION =~ /1\.9/
+    elsif RUBY_VERSION =~ /^1\.9/
       require '1.9/ffi_c'
-    elsif RUBY_VERSION =~ /2\.0/
+    elsif RUBY_VERSION =~ /^2\.0/
       require '2.0/ffi_c'
-    elsif RUBY_VERSION =~ /2\.1/
+    elsif RUBY_VERSION =~ /^2\.1/
       require '2.1/ffi_c'
-    elsif RUBY_VERSION =~ /2\.2/
+    elsif RUBY_VERSION =~ /^2\.2/
       require '2.2/ffi_c'
     else
       require 'ffi_c'


### PR DESCRIPTION
This is necessary to differentiate between 2.1.x and 2.2.1 ruby version
patterns. The pattern is also more accurately reflects the intention.

refs #419