### PR TITLE
Enable and fix warnings (esp. in Enum#native_type)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ require 'rubygems/package_task'
 
 RSpec::Core::RakeTask.new(:spec => :compile) do |config|
   config.rspec_opts = YAML.load_file 'spec/spec.opts'
+  config.ruby_opts = '-w'
 end
 
 
@@ -83,23 +84,23 @@ TEST_DEPS = [ LIBTEST ]
 if RUBY_PLATFORM == "java"
   desc "Run all specs"
   task :specs, [:options] => TEST_DEPS do |t, args|
-    sh %{#{Gem.ruby} -w -S rspec #{args.options || Dir["spec/ffi/*_spec.rb"].join(" ")} -fs --color}
+    sh %{#{Gem.ruby} -w -S rspec #{args.options || Dir["spec/ffi/*_spec.rb"].join(" ")} -fs}
   end
   desc "Run rubinius specs"
   task :rbxspecs => TEST_DEPS do
-    sh %{#{Gem.ruby} -w -S rspec #{Dir["spec/ffi/rbx/*_spec.rb"].join(" ")} -fs --color}
+    sh %{#{Gem.ruby} -w -S rspec #{Dir["spec/ffi/rbx/*_spec.rb"].join(" ")} -fs}
   end
 else
   TEST_DEPS.unshift :compile
   desc "Run all specs"
   task :specs, [:options] => TEST_DEPS do |t, args|
     ENV["MRI_FFI"] = "1"
-    sh %{#{Gem.ruby} -w -Ilib -I#{BUILD_EXT_DIR} -S rspec #{args.options || Dir["spec/ffi/*_spec.rb"].join(" ")} -fs --color}
+    sh %{#{Gem.ruby} -w -Ilib -I#{BUILD_EXT_DIR} -S rspec #{args.options || Dir["spec/ffi/*_spec.rb"].join(" ")} -fs}
   end
   desc "Run rubinius specs"
   task :rbxspecs => TEST_DEPS do
     ENV["MRI_FFI"] = "1"
-    sh %{#{Gem.ruby} -w -Ilib -I#{BUILD_EXT_DIR} -S rspec #{Dir["spec/ffi/rbx/*_spec.rb"].join(" ")} -fs --color}
+    sh %{#{Gem.ruby} -w -Ilib -I#{BUILD_EXT_DIR} -S rspec #{Dir["spec/ffi/rbx/*_spec.rb"].join(" ")} -fs}
   end
 end
 

--- a/lib/ffi/enum.rb
+++ b/lib/ffi/enum.rb
@@ -152,7 +152,7 @@ module FFI
     # Get native type of Enum
     # @return [Type]
     def native_type
-      @native_type || Type::INT
+      @native_type ||= Type::INT
     end
 
     # @param [Symbol, Integer, #to_int] val

--- a/spec/ffi/enum_spec.rb
+++ b/spec/ffi/enum_spec.rb
@@ -416,6 +416,38 @@ describe "All enums" do
     expect(enum[0x4242424242424243]).to be_nil
   end
 
+  it "know their own native type" do
+    enum = TestEnum3.enum_type(:enum_type1)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum3.enum_type(:enum_type2)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum3.enum_type(:enum_type3)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum3.enum_type(:enum_type4)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum4.enum_type(:enum_type1)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum4.enum_type(:enum_type2)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum4.enum_type(:enum_type3)
+    expect(enum.native_type).to eq FFI::Type::INT
+
+    enum = TestEnum4.enum_type(:enum_type4)
+    expect(enum.native_type).to eq FFI::Type::UINT16
+
+    enum = TestEnum4.enum_type(:enum_type5)
+    expect(enum.native_type).to eq FFI::Type::UINT32
+
+    enum = TestEnum4.enum_type(:enum_type6)
+    expect(enum.native_type).to eq FFI::Type::UINT64
+  end
+
   it "duplicate enum keys rejected" do
     expect { enum [ :a, 0xfee1dead, :b, 0xdeadbeef, :a, 0 ] }.to raise_error
     expect { enum FFI::Type::UINT64, [ :a, 0xfee1dead, :b, 0xdeadbeef, :a, 0 ] }.to raise_error

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -53,11 +53,7 @@ def compile_library(path, lib)
 
   dir = File.expand_path(path, File.dirname(__FILE__))
   lib = "#{dir}/#{lib}"
-  if !File.exists?(lib)
-    ldshared  = RbConfig::CONFIG["LDSHARED"] || "clang -dynamic -bundle"
-    libs      = RbConfig::CONFIG["LIBS"]
-    dldflags  = RbConfig::CONFIG["DLDFLAGS"] || "-Wl,-undefined,dynamic_lookup -Wl,-multiply_defined,suppress"
-
+  if !File.exist?(lib)
     puts Dir.pwd, dir, File.dirname(__FILE__)
 
     output = nil

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -102,7 +102,7 @@ describe "Struct tests" do
     smp = FFI::MemoryPointer.new :pointer
     s = PointerMember.new smp
     expect { s[:pointer] = s }.not_to raise_error Exception
-    expect { foo = s[:pointer] }.not_to raise_error Exception
+    expect { s[:pointer] }.not_to raise_error Exception
   end
 
   it "Struct#[:pointer]=nil" do

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,3 +1,2 @@
---color
 --format
 documentation


### PR DESCRIPTION
This pull request fixes a warning that occurs when `Enum#native_type` is called.

* Ensure warnings are emitted during spec runs: It appears the use of rspec's `--color` option also disables warnings. It seems this problem doesn't occur with rspec 3.
* Make sure Enum#native_type is tested before modifying it.
* Fix the warning in Enum#native_type and in two places in FFI's specs.

I also noticed both `spec` and `specs` task exist. It *seems* the latter is old and could be removed, but I was unsure so I modified both tasks to emit warnings.