### PR TITLE
Simplify cross build tasks and add rake-compiler-dock for building Windows binary gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 group :development do
   gem 'rake', '~> 10.1'
   gem 'rake-compiler', '~> 0.9.5'
+  gem 'rake-compiler-dock', '~> 0.3.1'
   gem 'rspec', '~> 3.0'
   gem 'rubygems-tasks', '~> 0.2.4', :require => 'rubygems/tasks'
   gem "rubysl", "~> 2.0", :platforms => 'rbx'

--- a/Rakefile
+++ b/Rakefile
@@ -169,26 +169,22 @@ if USE_RAKE_COMPILER
     ext.cross_platform = %w[i386-mingw32 x64-mingw32]                     # forces the Windows platform instead of the default one
   end
 
-  task 'gem:win32' => ['gem:win32-x64', 'gem:win32-i386']
+  ENV['RUBY_CC_VERSION'] ||= '1.8.7:1.9.3:2.0.0:2.1.5:2.2.1'
 
-  task 'gem:win32-i386' do
-    sh("rake cross native:i386-mingw32 gem RUBY_CC_VERSION='1.8.7:1.9.3:2.0.0:2.1.5:2.2.1'") || raise("win32-i386 build failed!")
-  end
-
-  task 'gem:win32-x64' do
-    sh("rake cross native:x64-mingw32 gem RUBY_CC_VERSION='2.0.0:2.1.5:2.2.1'") || raise("win32-x64 build failed!")
-  end
-
-  (ENV['RUBY_CC_VERSION'] || '1.8.7:1.9.3:2.0.0:2.1.5:2.2.1' ).to_s.split(':').each do |ruby_version|
+  ENV['RUBY_CC_VERSION'].to_s.split(':').each do |ruby_version|
     task "copy:ffi_c:i386-mingw32:#{ruby_version}" do |t|
       sh "i686-w64-mingw32-strip -S #{BUILD_DIR}/i386-mingw32/stage/lib/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so"
     end
-  end
 
-  (ENV['RUBY_CC_VERSION'] || '2.0.0:2.1.5:2.2.1' ).to_s.split(':').each do |ruby_version|
     task "copy:ffi_c:x64-mingw32:#{ruby_version}" do |t|
       sh "x86_64-w64-mingw32-strip -S #{BUILD_DIR}/x64-mingw32/stage/lib/#{ruby_version[/^\d+\.\d+/]}/ffi_c.so"
     end
+  end
+
+  desc "build a windows gem without all the ceremony."
+  task "gem:windows" do
+    require "rake_compiler_dock"
+    RakeCompilerDock.sh "bundle && rake cross native gem MAKE='nice make -j`nproc`'"
   end
 end
 

--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'rake-compiler-dock', '~> 0.3.1'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubygems-tasks', "~> 0.2.4"
 end


### PR DESCRIPTION
[rake-compiler-dock](https://github.com/larskanis/rake-compiler-dock) makes building Windows gems faster and with little to no setup compared to [rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box). A simple 'rake gem:windows' is usually enough.

The build is successfully tested on Linux and Windows. I tested all resulting gems on RubyInstaller versions 2.1.4-x64, 2.2.1-x86 and 2.2.1-x64 on Windows-7. However building on Windows requires UNIX end of line characters. So git should be used like this:

``` sh
  git clone -n https://github.com/ffi/ffi
  cd ffi
  git config core.autocrlf false
  git checkout add-rake-compiler-dock -f
  rake gem:windows
```

The cross ruby versions used by gem:windows are not passed to the container, so the rake-compiler-dock's defaults are used, which are currently [slightly different](https://github.com/larskanis/rake-compiler-dock/blob/master/src/runas).
