### PR TITLE
methodHandleParamTypes needs to refer to valid memory after rbffi_MethodHandle_Init

### DIFF
--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -132,6 +132,12 @@ rbffi_MethodHandle_CodeAddress(MethodHandle* handle)
 #ifndef CUSTOM_TRAMPOLINE
 static void attached_method_invoke(ffi_cif* cif, void* retval, METHOD_PARAMS parameters, void* user_data);
 
+static ffi_type* methodHandleParamTypes[] = {
+    &ffi_type_sint,
+    &ffi_type_pointer,
+    &ffi_type_ulong,
+};
+
 static ffi_cif mh_cif;
 
 static bool
@@ -333,12 +339,7 @@ void
 rbffi_MethodHandle_Init(VALUE module)
 {
 #ifndef CUSTOM_TRAMPOLINE
-    ffi_status ffiStatus;	
-    ffi_type* methodHandleParamTypes[] = {
-        &ffi_type_sint,
-        &ffi_type_pointer,
-        &ffi_type_ulong,
-    };
+    ffi_status ffiStatus;
 #endif
 
     defaultClosurePool = rbffi_ClosurePool_New((int) trampoline_size(), prep_trampoline, NULL);


### PR DESCRIPTION
Fixes #440