### PR TITLE
Update version of rake-compiler-dock to 0.4.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :development do
   gem 'rake', '~> 10.1'
   gem 'rake-compiler', '~> 0.9.5'
-  gem 'rake-compiler-dock', '~> 0.3.1'
+  gem 'rake-compiler-dock', '~> 0.4.0'
   gem 'rspec', '~> 3.0'
   gem 'rubygems-tasks', '~> 0.2.4', :require => 'rubygems/tasks'
   gem "rubysl", "~> 2.0", :platforms => 'rbx'

--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
-  s.add_development_dependency 'rake-compiler-dock', '~> 0.3.1'
+  s.add_development_dependency 'rake-compiler-dock', '~> 0.4.0'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubygems-tasks', "~> 0.2.4"
 end


### PR DESCRIPTION
Nothing really important, but version 0.4.0 adds OS-X support, some automatic handling of boot2docker and better diagnosis.