### PR TITLE
FFI::AutoPointer::Releaser#call: call #free instead of #release

### DIFF
--- a/lib/ffi/autopointer.rb
+++ b/lib/ffi/autopointer.rb
@@ -141,7 +141,7 @@ module FFI
       # @param args
       # Release pointer if +autorelease+ is set.
       def call(*args)
-        release(@ptr) if @autorelease && @ptr
+        free if @autorelease
       end
       
     end


### PR DESCRIPTION
I'm pretty sure that #free should be called instead of #release.

#free will conditionally call #release (if `@ptr` is set) and, if so, also set `@ptr` and `@proc` to `nil` and `@autorelease` to `false`.