### PR TITLE
when use `FFI.typedef :ORITYPE, :TYPEXXX` define a type alisname

### DIFF
--- a/lib/ffi/abstractmemory.rb
+++ b/lib/ffi/abstractmemory.rb
@@ -1,0 +1,27 @@
+
+module FFI
+  class AbstractMemory
+    # for TYPEXXX in FFI::TypeDefs.keys
+    #  add respond_to? [:put_TYPEXXX, :get_TYPEXXX,
+    #                   :write_TYPEXXX, :read_TYPEXXX,
+    #                   :put_array_of_TYPEXXX, :get_array_of_TYPEXXX,
+    #                   :write_array_of_TYPEXXX, :read_array_of_TYPEXXX]
+    def method_missing method_name, *args, &block
+      if /^(?<oper>(?:put|get|write|read)_(?:array_of_)?)(?<type_name>[[:word:]]+)$/ =~ method_name.to_s
+        if builtintype = FFI::TypeDefs[type_name.intern] || FFI::TypeDefs[type_name]
+          if /FFI\:\:Type\:\:Builtin\:(?<ori_type>[[:word:]]+)/ =~ builtintype.inspect
+            ori_method1 = "#{oper}#{ori_type}"
+            ori_method2 = "#{oper}#{ori_type.downcase}"
+            if respond_to?(ori_method1, true)
+              return send(ori_method1, *args, &block)
+            elsif respond_to?(ori_method2, true)
+              return send(ori_method2, *args, &block)
+            end
+          end
+        end
+      end
+
+      super
+    end
+  end
+end

--- a/lib/ffi/ffi.rb
+++ b/lib/ffi/ffi.rb
@@ -28,6 +28,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+require 'ffi/abstractmemory'
 require 'ffi/platform'
 require 'ffi/types'
 require 'ffi/library'

--- a/spec/ffi/abstractmemory_method_missing_spec.rb
+++ b/spec/ffi/abstractmemory_method_missing_spec.rb
@@ -1,0 +1,23 @@
+
+require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
+
+describe "abstract memory" do
+  it 'method missing' do
+    FFI.typedef :uint64, :TYPEXXX
+    v1, v2, v3, v4 = 0xFE01020304050607, 0xFE01020304050608, 0xFE01020304050609, 0xFE0102030405060A
+
+    aa=FFI::Buffer.new(:TYPEXXX, 4)
+
+    aa.write_TYPEXXX(v1)
+    expect(aa.read_TYPEXXX).to eq(v1)
+
+    aa.put_TYPEXXX(8, v2)
+    expect(aa.get_TYPEXXX(8)).to eq(v2)
+
+    aa.write_array_of_TYPEXXX([v1, v2, v4, v3])
+    expect(aa.read_array_of_TYPEXXX(4)).to eq([v1, v2, v4, v3])
+
+    aa.put_array_of_TYPEXXX 16, [v3, v4]
+    expect(aa.get_array_of_TYPEXXX(0, 4)).to eq([v1, v2, v3, v4])
+  end
+end


### PR DESCRIPTION
when use `FFI.typedef :ORITYPE, :TYPEXXX` define a type alisname

    FFI::AbstractMemory instance can respond_to? [:put_TYPEXXX, :get_TYPEXXX,
                   :write_TYPEXXX, :read_TYPEXXX,
                   :put_array_of_TYPEXXX, :get_array_of_TYPEXXX,
                   :write_array_of_TYPEXXX, :read_array_of_TYPEXXX]