### PR TITLE
Typo Fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -138,7 +138,7 @@ end
 task 'spec:run' => TEST_DEPS
 task 'spec:specdoc' => TEST_DEPS
 
-task :default => :specs
+task :default => :spec
 
 namespace 'java' do
 

--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -497,7 +497,7 @@ memory_put_bytes(int argc, VALUE* argv, VALUE self)
     off = NUM2LONG(offset);
     idx = nargs > 2 ? NUM2LONG(rbIndex) : 0;
     if (idx < 0) {
-        rb_raise(rb_eRangeError, "index canot be less than zero");
+        rb_raise(rb_eRangeError, "index cannot be less than zero");
         return Qnil;
     }
     len = nargs > 3 ? NUM2LONG(rbLength) : (RSTRING_LEN(str) - idx);

--- a/ext/ffi_c/Buffer.c
+++ b/ext/ffi_c/Buffer.c
@@ -253,7 +253,7 @@ buffer_inspect(VALUE self)
  * @overload order(order)
  *  @param [:big, :little, :network] order
  *  @return [self]
- *  Set endinaness of Buffer (+:network+ is an alias for +:big+).
+ *  Set endianness of Buffer (+:network+ is an alias for +:big+).
  */
 static VALUE
 buffer_order(int argc, VALUE* argv, VALUE self)

--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -243,10 +243,10 @@ static VALUE custom_trampoline(caddr_t args, Closure*);
 #define TRAMPOLINE_FUN_MAGIC (0xbeefcafe)
 
 /*
- * This is a hand-coded trampoline to speedup entry from ruby to the FFI translation
+ * This is a hand-coded trampoline to speed-up entry from ruby to the FFI translation
  * layer for i386 arches.
  *
- * This does not make a discernable difference vs a raw closure, so for now,
+ * This does not make a discernible difference vs a raw closure, so for now,
  * it is not enabled.
  */
 __asm__(

--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -89,7 +89,7 @@ ptr_allocate(VALUE klass)
  * @overload initialize(type, address)
  *  @param [Type] type type for pointer
  *  @param [Integer] address base address for pointer
- *  Create a new pointer from a {Type} and a base adresse
+ *  Create a new pointer from a {Type} and a base address
  * @return [self]
  * A new instance of Pointer.
  */
@@ -146,11 +146,11 @@ ptr_initialize(int argc, VALUE* argv, VALUE self)
  * call-seq: ptr.initialize_copy(other)
  * @param [Pointer] other source for cloning or dupping
  * @return [self]
- * @raise {RuntimeError} if +other+ is an unbounded memory area, or is unreable/unwritable
+ * @raise {RuntimeError} if +other+ is an unbounded memory area, or is unreadable/unwritable
  * @raise {NoMemError} if failed to allocate memory for new object
  * DO NOT CALL THIS METHOD.
  *
- * This method is internally used by #dup and #clone. Memory contents is copied from +other+.
+ * This method is internally used by #dup and #clone. Memory content is copied from +other+.
  */
 static VALUE
 ptr_initialize_copy(VALUE self, VALUE other)


### PR DESCRIPTION
Context
----------

I have been auditing some third-party Gems for memory errors (such as those addressed by 098dcfba). 

Change
-----------

While I was reading through this codebase, I found a few typos and fixed them up.