### PR TITLE
Support ruby 2.1.8

### DIFF
--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -341,7 +341,7 @@ module FFI
       # @raise if Ruby 1.8
       # Add hash +spec+ to +builder+.
       def hash_layout(builder, spec)
-        raise "Ruby version not supported" if RUBY_VERSION =~ /1\.8\.*/
+        raise "Ruby version not supported" if RUBY_VERSION =~ /^1\.8\..*/
         spec[0].each do |name, type|
           builder.add name, find_field_type(type), nil
         end

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -7,7 +7,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
 
 describe "Struct aligns fields correctly" do
   it "char, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /1.8.*/
+    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class CIStruct < FFI::Struct
       layout :c => :char, :i => :int
     end
@@ -15,7 +15,7 @@ describe "Struct aligns fields correctly" do
   end
 
   it "short, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /1.8.*/
+    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class SIStruct < FFI::Struct
       layout :s => :short, :i => :int
     end
@@ -23,7 +23,7 @@ describe "Struct aligns fields correctly" do
   end
 
   it "int, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /1.8.*/
+    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class IIStruct < FFI::Struct
       layout :i1 => :int, :i => :int
     end
@@ -31,7 +31,7 @@ describe "Struct aligns fields correctly" do
   end
 
   it "long long, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /1.8.*/
+    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class LLIStruct < FFI::Struct
       layout :l => :long_long, :i => :int
     end


### PR DESCRIPTION
On ruby 2.1.8, this code is fail. (2.1.7 is success)

```ruby
require 'ffi'

class Foo < FFI::Struct
  layout foo: :bar
end
```

```
.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/ffi-1.9.10/lib/ffi/struct.rb:344:in `hash_layout': Ruby version not supported (RuntimeError)
```

And current ffi testing code, skip this check since this change https://github.com/ffi/ffi/commit/f75b924ff3abd4c80c66111f1f9c2bbeeb70a171#diff-83f16e6ed1c44a9ced98f69d4139c564


```ruby
"2.1.8" =~ /1\.8\.*/ #=> 2
"2.1.8" =~ /1.8.*/ #=> 2
```

I expect to work `hash_layout` on ruby 2.1.8