### PR TITLE
Drop Ruby 1.8.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ os:
   - osx
 rvm:
   - "1.9.3"
-  - "1.8.7"
   - "2.0.0"
   - "2.1"
   - "2.2.3"
@@ -32,7 +31,6 @@ matrix:
       rvm: ruby-head
     - rvm: "rbx"
     - rvm: "rbx-head"
-    - rvm: "1.8.7"
     - rvm: "1.9.3"
 after_failure:
   - "find build -name mkmf.log | xargs cat"

--- a/Rakefile
+++ b/Rakefile
@@ -175,7 +175,7 @@ if USE_RAKE_COMPILER
     ext.cross_platform = %w[i386-mingw32 x64-mingw32]                     # forces the Windows platform instead of the default one
   end
 
-  ENV['RUBY_CC_VERSION'] ||= '1.8.7:1.9.3:2.0.0:2.1.6:2.2.2:2.3.0'
+  ENV['RUBY_CC_VERSION'] ||= '1.9.3:2.0.0:2.1.6:2.2.2:2.3.0'
 
   # To reduce the gem file size strip mingw32 dlls before packaging
   ENV['RUBY_CC_VERSION'].to_s.split(':').each do |ruby_version|

--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = %w[--exclude=ext/ffi_c/.*\.o$ --exclude=ffi_c\.(bundle|so)$]
   s.license = 'BSD'
   s.require_paths << 'ext/ffi_c'
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.9'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.5.2'

--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -338,10 +338,8 @@ module FFI
       # @param [StructLayoutBuilder] builder
       # @param [Hash] spec
       # @return [builder]
-      # @raise if Ruby 1.8
       # Add hash +spec+ to +builder+.
       def hash_layout(builder, spec)
-        raise "Ruby version not supported" if RUBY_VERSION =~ /^1\.8\..*/
         spec[0].each do |name, type|
           builder.add name, find_field_type(type), nil
         end

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -7,7 +7,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
 
 describe "Struct aligns fields correctly" do
   it "char, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class CIStruct < FFI::Struct
       layout :c => :char, :i => :int
     end
@@ -15,7 +14,6 @@ describe "Struct aligns fields correctly" do
   end
 
   it "short, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class SIStruct < FFI::Struct
       layout :s => :short, :i => :int
     end
@@ -23,7 +21,6 @@ describe "Struct aligns fields correctly" do
   end
 
   it "int, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class IIStruct < FFI::Struct
       layout :i1 => :int, :i => :int
     end
@@ -31,7 +28,6 @@ describe "Struct aligns fields correctly" do
   end
 
   it "long long, followed by an int" do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     class LLIStruct < FFI::Struct
       layout :l => :long_long, :i => :int
     end


### PR DESCRIPTION
[It seems that Ruby FFI does not support Ruby 1.8.7 and earlier.](https://github.com/ffi/ffi/pull/479/files)

I propose that required ruby version will be specified to `gemspec` file.

Thanks.
