### PR TITLE
Check the arity of the 'find_type' method

### DIFF
--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -305,7 +305,7 @@ module FFI
       def enclosing_module
         begin
           mod = self.name.split("::")[0..-2].inject(Object) { |obj, c| obj.const_get(c) }
-          (mod < FFI::Library || mod < FFI::Struct || mod.respond_to?(:find_type)) ? mod : nil
+          (mod < FFI::Library || mod < FFI::Struct || (mod.respond_to?(:find_type) && [1, -2].include?(mod.method(:find_type).arity))) ? mod : nil
         rescue Exception
           nil
         end


### PR DESCRIPTION
While loading `pry` console I see the error:

```
ArgumentError: wrong number of arguments (given 1, expected 2+)
.../gems/ffi-1.9.10/lib/ffi/struct.rb:332:in `find_type'
.../gems/ffi-1.9.10/lib/ffi/struct.rb:326:in `find_field_type'
.../gems/ffi-1.9.10/lib/ffi/struct.rb:368:in `array_layout'
.../gems/ffi-1.9.10/lib/ffi/struct.rb:278:in `layout'
.../gems/scrypt-2.0.2/lib/scrypt.rb:139:in `<class:Calibration>'
.../gems/scrypt-2.0.2/lib/scrypt.rb:138:in `<class:Engine>'
.../gems/scrypt-2.0.2/lib/scrypt.rb:23:in `<module:SCrypt>'
.../gems/scrypt-2.0.2/lib/scrypt.rb:9:in `<top (required)>'
```

After some digging I found that it loads `find_type` from here
`["/home/viktor/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/mkmf.rb", 1237]`
Actually, don't know why. While `p enclosing_module` says `SCrypt::Engine`.

Probably, there might be better fix
