### PR TITLE
remove RB_GC_GUARD_PTR references

### DIFF
--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -228,9 +228,8 @@ custom_trampoline(int argc, VALUE* argv, VALUE self, Closure* handle)
 {
     FunctionType* fnInfo = (FunctionType *) handle->info;
     VALUE rbReturnValue;
-    
+
     RB_GC_GUARD(rbReturnValue) = (*fnInfo->invoke)(argc, argv, handle->function, fnInfo);
-    RB_GC_GUARD_PTR(argv);
     RB_GC_GUARD(self);
 
     return rbReturnValue;
@@ -357,4 +356,3 @@ rbffi_MethodHandle_Init(VALUE module)
 
 #endif
 }
-

--- a/ext/ffi_c/compat.h
+++ b/ext/ffi_c/compat.h
@@ -75,9 +75,4 @@
 #  define RB_GC_GUARD(x) (x)
 #endif
 
-#ifndef RB_GC_GUARD_PTR
-#  define RB_GC_GUARD_PTR(x) (x)
-#endif
-
 #endif /* RBFFI_COMPAT_H */
-


### PR DESCRIPTION
it seems like the ruby authors do not intend for this to be an external
API.

closes #489 