### PR TITLE
chore(travis): test against Ruby 2.1.10 and 2.2.4. I cannot build ffi on 2.1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ rvm:
   - "1.9.3"
   - "1.8.7"
   - "2.0.0"
-  - "2.1"
-  - "2.2"
+  - "2.1.10"
+  - "2.2.4"
   - "ruby-head"
   - "rbx"
   - "system"
@@ -20,7 +20,7 @@ matrix:
   allow_failures:
     - rvm: system
     - os: osx
-      rvm: "2.2"
+      rvm: "2.2.4"
     - os: osx
       rvm: ruby-head
     - rvm: "rbx"


### PR DESCRIPTION
In travis-ci, 2.1 means 2.1.5, and 2.2 means 2.2.0.
But latest is 2.1.10 and 2.2.4.

I cannot build `byebug` with Ruby 2.1.10.
chore(travis): test against ruby 2.1.10
https://github.com/deivid-rodriguez/byebug/pull/236
https://travis-ci.org/deivid-rodriguez/byebug/jobs/121867657
~~I think this is `ffi`'s issue.~~
This is `rvm`'s or `travis-rubies`'s issue.

ffi v1.9.10