### PR TITLE
Update for ruby-2.3 cross build and travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+sudo: false
+addons:
+  apt:
+    packages:
+    - libgmp-dev    # this is needed for ruby-2.1.10 and ruby-head on linux
 language: ruby
+before_install:
+  - gem install bundler
 script: bundle exec rake test
-before_install: gem install bundler
 os:
   - linux
   - osx
@@ -9,8 +15,8 @@ rvm:
   - "1.8.7"
   - "2.0.0"
   - "2.1"
-  - "2.2"
-  - "2.3"
+  - "2.2.3"
+  - "2.3.0"
   - "ruby-head"
   - "rbx"
   - "system"
@@ -21,8 +27,7 @@ matrix:
   allow_failures:
     - rvm: system
     - os: osx
-      rvm: "2.2"
-      rvm: "2.3"
+      rvm: "2.3.0"
     - os: osx
       rvm: ruby-head
     - rvm: "rbx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - "2.0.0"
   - "2.1"
   - "2.2"
+  - "2.3"
   - "ruby-head"
   - "rbx"
   - "system"
@@ -21,6 +22,7 @@ matrix:
     - rvm: system
     - os: osx
       rvm: "2.2"
+      rvm: "2.3"
     - os: osx
       rvm: ruby-head
     - rvm: "rbx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ matrix:
     - rvm: "rbx-head"
     - rvm: "1.8.7"
     - rvm: "1.9.3"
+after_failure:
+  - "find build -name mkmf.log | xargs cat"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :development do
   gem 'rake', '~> 10.1'
   gem 'rake-compiler', '~> 0.9.5'
-  gem 'rake-compiler-dock', '~> 0.4.0'
+  gem 'rake-compiler-dock', '~> 0.5.2'
   gem 'rspec', '~> 3.0'
   gem 'rubygems-tasks', '~> 0.2.4', :require => 'rubygems/tasks'
   gem "rubysl", "~> 2.0", :platforms => 'rbx'

--- a/Rakefile
+++ b/Rakefile
@@ -175,7 +175,7 @@ if USE_RAKE_COMPILER
     ext.cross_platform = %w[i386-mingw32 x64-mingw32]                     # forces the Windows platform instead of the default one
   end
 
-  ENV['RUBY_CC_VERSION'] ||= '1.8.7:1.9.3:2.0.0:2.1.6:2.2.2'
+  ENV['RUBY_CC_VERSION'] ||= '1.8.7:1.9.3:2.0.0:2.1.6:2.2.2:2.3.0'
 
   # To reduce the gem file size strip mingw32 dlls before packaging
   ENV['RUBY_CC_VERSION'].to_s.split(':').each do |ruby_version|

--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
-  s.add_development_dependency 'rake-compiler-dock', '~> 0.4.0'
+  s.add_development_dependency 'rake-compiler-dock', '~> 0.5.2'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubygems-tasks', "~> 0.2.4"
 end


### PR DESCRIPTION
ruby-2.2.4 and ruby-2.1.10 are not yet available for OSX on travis, so that I used the latest versions, that are available on both platforms.

This includes #493 .