### PR TITLE
Switch to using container-based Travis where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 script: bundle exec rake test
 before_install: gem install bundler
 os:


### PR DESCRIPTION
This makes the CI process a bit faster and a bit less resource
intensive. OS X builds run as usual.