### PR TITLE
Sets the srcdir to ensure build targets are relative

### DIFF
--- a/ext/ffi_c/libffi.bsd.mk
+++ b/ext/ffi_c/libffi.bsd.mk
@@ -28,7 +28,7 @@ $(LIBFFI):
 	    echo "Configuring libffi"; \
 	    cd ${LIBFFI_BUILD_DIR} && \
 		/usr/bin/env CC="${CC}" LD="${LD}" CFLAGS="${LIBFFI_CFLAGS}" GREP_OPTIONS="" \
-		/bin/sh ${LIBFFI_CONFIGURE} ${LIBFFI_HOST} > /dev/null; \
+		/bin/sh ${LIBFFI_CONFIGURE} --srcdir ../libffi ${LIBFFI_HOST} > /dev/null; \
 	fi
 	@cd ${LIBFFI_BUILD_DIR} && ${MAKE}
 

--- a/ext/ffi_c/libffi.darwin.mk
+++ b/ext/ffi_c/libffi.darwin.mk
@@ -32,7 +32,7 @@ $(LIBFFI):
 	    echo "Configuring libffi"; \
 	    cd "$(LIBFFI_BUILD_DIR)" && \
 		/usr/bin/env CC="$(CC)" LD="$(LD)" CFLAGS="$(LIBFFI_CFLAGS)" GREP_OPTIONS="" \
-		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) > /dev/null; \
+		/bin/sh $(LIBFFI_CONFIGURE) --srcdir ../libffi $(LIBFFI_HOST) > /dev/null; \
 	fi
 	cd "$(LIBFFI_BUILD_DIR)" && $(MAKE)
 

--- a/ext/ffi_c/libffi.mk
+++ b/ext/ffi_c/libffi.mk
@@ -8,6 +8,6 @@ $(LIBFFI):
 	    echo "Configuring libffi"; \
 	    cd "$(LIBFFI_BUILD_DIR)" && \
 		/usr/bin/env CFLAGS="$(LIBFFI_CFLAGS)" GREP_OPTIONS="" \
-		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) > /dev/null; \
+		/bin/sh $(LIBFFI_CONFIGURE) --srcdir ../libffi $(LIBFFI_HOST) > /dev/null; \
 	fi
 	$(MAKE) -C "$(LIBFFI_BUILD_DIR)"


### PR DESCRIPTION
Without this change we end up linking to an absolute path:

```
config.status: linking
/home/vagrant/ffi/ext/ffi_c/libffi/src/x86/ffitarget.h to
include/ffitarget.h
```

This makes it difficult to package bundled artefacts for distribution and installation to different directories. 