### PR TITLE
Support blocking: true for varargs calls

### DIFF
--- a/ext/ffi_c/Call.h
+++ b/ext/ffi_c/Call.h
@@ -33,6 +33,8 @@
 #ifndef RBFFI_CALL_H
 #define	RBFFI_CALL_H
 
+#include "Thread.h"
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
@@ -84,6 +86,21 @@ Invoker rbffi_GetInvoker(struct FunctionType_* fnInfo);
 
 extern VALUE rbffi_GetEnumValue(VALUE enums, VALUE value);
 extern int rbffi_GetSignedIntValue(VALUE value, int type, int minValue, int maxValue, const char* typeName, VALUE enums);
+
+typedef struct rbffi_blocking_call {
+    rbffi_frame_t* frame;
+    void* function;
+    ffi_cif cif;
+    void **ffiValues;
+    void* retval;
+    void* params;
+#if !(defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL))
+    void* stkretval;
+#endif
+} rbffi_blocking_call_t;
+
+VALUE rbffi_do_blocking_call(void* data);
+VALUE rbffi_save_frame_exception(void *data, VALUE exc);
 
 #ifdef	__cplusplus
 }

--- a/spec/ffi/fixtures/FunctionTest.c
+++ b/spec/ffi/fixtures/FunctionTest.c
@@ -62,10 +62,10 @@ void testBlockingClose(struct testBlockingData *self) {
     free(self);
 }
 
-static char sum_varargs(va_list args) {
+static int sum_varargs(va_list args) {
     char sum = 0;
-    char arg;
-    while ((arg = va_arg(args, char)) != 0) {
+    int arg;
+    while ((arg = va_arg(args, int)) != 0) {
         sum += arg;
     }
     va_end(args);

--- a/spec/ffi/fixtures/FunctionTest.c
+++ b/spec/ffi/fixtures/FunctionTest.c
@@ -11,6 +11,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <pthread.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #endif
 
@@ -59,6 +60,37 @@ void testBlockingClose(struct testBlockingData *self) {
     pipeHelperClosePipe(self->pipe2[0]);
     pipeHelperClosePipe(self->pipe2[1]);
     free(self);
+}
+
+char testBlockingWRva(struct testBlockingData *self, char c, ...) {
+    /* Process argument list but ignore values */
+    va_list args;
+    va_start(args, c);
+    char arg;
+    while ((arg = va_arg(args, char)) != 0) {
+        continue;
+    }
+    va_end(args);
+
+    if( pipeHelperWriteChar(self->pipe1[1], c) != 1)
+        return 0;
+    return pipeHelperReadChar(self->pipe2[0], 10);
+}
+
+char testBlockingRWva(struct testBlockingData *self, char c, ...) {
+    /* Process argument list but ignore values */
+    va_list args;
+    va_start(args, c);
+    char arg;
+    while ((arg = va_arg(args, char)) != 0) {
+        continue;
+    }
+    va_end(args);
+
+    char d = pipeHelperReadChar(self->pipe1[0], 10);
+    if( pipeHelperWriteChar(self->pipe2[1], c) != 1)
+        return 0;
+    return d;
 }
 
 struct async_data {

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -36,8 +36,8 @@ describe "Function with variadic arguments" do
     handle = LibTest.testBlockingOpen
     expect(handle).not_to be_null
     begin
-      thWR = Thread.new { LibTest.testBlockingWRva(handle, 63, :char, 40, :char, 23, :char, 0) }
-      thRW = Thread.new { LibTest.testBlockingRWva(handle, 64, :char, 40, :char, 24, :char, 0) }
+      thWR = Thread.new { LibTest.testBlockingWRva(handle, 63, :int, 40, :int, 23, :int, 0) }
+      thRW = Thread.new { LibTest.testBlockingRWva(handle, 64, :int, 40, :int, 24, :int, 0) }
       expect(thWR.value).to eq(64)
       expect(thRW.value).to eq(63)
     ensure

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -33,6 +33,7 @@ describe "Function with variadic arguments" do
   end
 
   it 'can wrap a blocking function with varargs' do
+    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     handle = LibTest.testBlockingOpen
     expect(handle).not_to be_null
     begin

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -13,6 +13,11 @@ describe "Function with variadic arguments" do
     enum :enum_type2, [:c3, 42, :c4]
     attach_function :pack_varargs, [ :buffer_out, :string, :varargs ], :void
     attach_function :pack_varargs2, [ :buffer_out, :enum_type1, :string, :varargs ], :enum_type1
+
+    attach_function :testBlockingOpen, [ ], :pointer
+    attach_function :testBlockingRWva, [ :pointer, :char, :varargs ], :char, :blocking => true
+    attach_function :testBlockingWRva, [ :pointer, :char, :varargs ], :char, :blocking => true
+    attach_function :testBlockingClose, [ :pointer ], :void
   end
 
   it "takes enum arguments" do
@@ -25,6 +30,19 @@ describe "Function with variadic arguments" do
   it "returns symbols for enums" do
     buf = FFI::Buffer.new :long_long, 2
     expect(LibTest.pack_varargs2(buf, :c1, "ii", :int, :c3, :int, :c4)).to eq(:c2)
+  end
+
+  it 'can wrap a blocking function with varargs' do
+    handle = LibTest.testBlockingOpen
+    expect(handle).not_to be_null
+    begin
+      thWR = Thread.new { LibTest.testBlockingWRva(handle, 63, :char, 0) }
+      thRW = Thread.new { LibTest.testBlockingRWva(handle, 64, :char, 0) }
+      expect(thWR.value).to eq(64)
+      expect(thRW.value).to eq(63)
+    ensure
+      LibTest.testBlockingClose(handle)
+    end
   end
 
   [ 0, 127, -128, -1 ].each do |i|

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -36,8 +36,8 @@ describe "Function with variadic arguments" do
     handle = LibTest.testBlockingOpen
     expect(handle).not_to be_null
     begin
-      thWR = Thread.new { LibTest.testBlockingWRva(handle, 63, :char, 0) }
-      thRW = Thread.new { LibTest.testBlockingRWva(handle, 64, :char, 0) }
+      thWR = Thread.new { LibTest.testBlockingWRva(handle, 63, :char, 40, :char, 23, :char, 0) }
+      thRW = Thread.new { LibTest.testBlockingRWva(handle, 64, :char, 40, :char, 24, :char, 0) }
       expect(thWR.value).to eq(64)
       expect(thRW.value).to eq(63)
     ensure


### PR DESCRIPTION
As reported in #488, `blocking: true` does not work for varargs calls.

I’ve gotten it working by:
  - Adding a unit test based on the “can wrap a blocking function” spec in `function_spec.rb`
  - Making a typedef and a few functions in `Call.c` public
  - Calling those functions in `Variadic.c` if `HAVE_RB_THREAD_CALL_WITHOUT_GVL` is defined.

This makes `blocking: true` work, and the unit test pass, on modern Rubies. Rubies that require more work to support `blocking: true` will get the old behaviour.