### PR TITLE
Fix library name for symbols

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -125,10 +125,10 @@ module FFI
               # TODO better library lookup logic
               unless libname.to_s.start_with?("/")
                 path = ['/usr/lib/','/usr/local/lib/'].find do |pth|
-                  File.exist?(pth + libname)
+                  File.exist?(pth + libname.to_s)
                 end
                 if path
-                  libname = path + libname
+                  libname = path + libname.to_s
                   retry
                 end
               end


### PR DESCRIPTION
`libname` needs to be converted to a string whenever it is concatenated, currently I'm getting:

    C:/Ruby22-x64/lib/ruby/gems/2.2.0/gems/ffi-1.9.12-x64-mingw32/lib/ffi/library.rb:129:in `+': no implicit conversion of Symbol into String (TypeError)

This fixes that error.