### PR TITLE
fix library loading by symbol with test

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -123,7 +123,8 @@ module FFI
               end
 
               # TODO better library lookup logic
-              unless libname.to_s.start_with?("/")
+              libname = libname.to_s
+              unless libname.start_with?("/")
                 path = ['/usr/lib/','/usr/local/lib/'].find do |pth|
                   File.exist?(pth + libname)
                 end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -96,6 +96,16 @@ describe "Library" do
       }.not_to raise_error
     end
 
+    it "loads library using symbol" do
+      expect {
+        expect(Module.new do |m|
+          m.extend FFI::Library
+          ffi_lib :c
+          attach_function :getpid, [ ], :uint
+        end.getpid).to eq(Process.pid)
+      }.not_to raise_error
+    end
+
     it "attach_function :getpid from [ 'c', 'libc.so.6'] " do
       expect {
         expect(Module.new do |m|


### PR DESCRIPTION
This seems to fix scenarios where the library is provided via a symbol and adds a test for this condition.