### PR TITLE
Fix for symbol problems in ffi_lib on windows

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -103,7 +103,7 @@ module FFI
           FFI::DynamicLibrary.open(nil, FFI::DynamicLibrary::RTLD_LAZY | FFI::DynamicLibrary::RTLD_LOCAL)
 
         else
-          libnames = (name.is_a?(::Array) ? name : [ name ]).map { |n| [ n, FFI.map_library_name(n) ].uniq }.flatten.compact
+          libnames = (name.is_a?(::Array) ? name : name.is_a?(::String) ? [ name ] : [ name.to_s ]).map { |n| [ n, FFI.map_library_name(n) ].uniq }.flatten.compact
           lib = nil
           errors = {}
 
@@ -123,7 +123,7 @@ module FFI
               end
 
               # TODO better library lookup logic
-              unless libname.to_s.start_with?("/")
+              unless libname.start_with?('/')
                 path = ['/usr/lib/','/usr/local/lib/'].find do |pth|
                   File.exist?(pth + libname)
                 end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -62,6 +62,15 @@ describe "Library" do
       po = FFI::MemoryPointer.new :long
       LibTestStdcall.testStdcallManyParams po, 1, 2, 3, 4, s, s, 1.0, 2.0
     end
+
+    it "symbol should not raise error" do
+      expect {
+        Module.new do |m|
+          m.extend FFI::Library
+          ffi_lib :kernel32
+        end
+      }.not_to raise_error(LoadError)
+    end
   end
 
   describe "ffi_lib" do


### PR DESCRIPTION
I tested the change to ffi/library.rb locally by simply modifying my 1.9.11 gem install.

Unfortunately I don't have a full local C dev environment, so I can't run the rake build to test this out locally.

I think we should have a unit test over this problem, however I don't know if the test I added is worth anything at all.  If I could build it locally, I would definitely run it through its paces, and even make sure I had a failing test or two before submitting this pull request.  Sorry for not having enough ruby / native experience to help out in that area.

Hopefully the travis-ci build will help determine whether I broke something for other platforms.  I'm guessing my new unit test won't actually run there.