### PR TITLE
Use a standard spfx license

### DIFF
--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.extensions << 'ext/ffi_c/extconf.rb'
   s.has_rdoc = false
   s.rdoc_options = %w[--exclude=ext/ffi_c/.*\.o$ --exclude=ffi_c\.(bundle|so)$]
-  s.license = 'BSD'
+  s.license = 'BSD-3-Clause'
   s.require_paths << 'ext/ffi_c'
   s.required_ruby_version = '>= 1.8.7'
   s.add_development_dependency 'rake', '~> 10.1'


### PR DESCRIPTION
```console
$ gem build ffi.gemspec
WARNING:  WARNING: license value 'BSD' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
```