### PR TITLE
Add AbstractMemory#get and AbstractMemory#put

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -130,5 +130,26 @@ module FFI
       }
       self
     end
+
+    # @param [Symbol,Type] type of data to read
+    # @return [Object]
+    # Read pointer's contents as +type+
+    #
+    # Same as:
+    #  ptr.get(type, 0)
+    def read(type)
+      get(type, 0)
+    end
+
+    # @param [Symbol,Type] type of data to read
+    # @param [Object] value to write
+    # @return [nil]
+    # Write +value+ of type +type+ to pointer's content
+    #
+    # Same as:
+    #  ptr.put(type, 0)
+    def write(type, value)
+      put(type, 0, value)
+    end
   end
 end

--- a/spec/ffi/rbx/memory_pointer_spec.rb
+++ b/spec/ffi/rbx/memory_pointer_spec.rb
@@ -52,12 +52,76 @@ describe "MemoryPointer" do
     m = FFI::MemoryPointer.new(:int)
     m.write_int(1)
     expect(m.read_int).to eq(1)
+    expect(m.read :int).to eq(1)
+    expect(m.read FFI::Type::INT).to eq(1)
   end
-  
+
+  it "allows writing as a sized int" do
+    m = FFI::MemoryPointer.new(:uint32)
+    m.write_uint32(1)
+    expect(m.read_uint32).to eq(1)
+    expect(m.read :uint32).to eq(1)
+    expect(m.read FFI::Type::UINT32).to eq(1)
+
+    m = FFI::MemoryPointer.new(:uint32)
+    m.write :uint32, 1
+    expect(m.read :uint32).to eq(1)
+
+    m = FFI::MemoryPointer.new(:int64)
+    m.write_int64(1)
+    expect(m.read_int64).to eq(1)
+    expect(m.read :int64).to eq(1)
+    expect(m.read FFI::Type::INT64).to eq(1)
+
+    m = FFI::MemoryPointer.new(:int64)
+    m.write :int64, 1
+    expect(m.read :int64).to eq(1)
+  end
+
   it "allows writing as a long" do
     m = FFI::MemoryPointer.new(:long)
     m.write_long(10)
     expect(m.read_long).to eq(10)
+    expect(m.read :long).to eq(10)
+    expect(m.read FFI::Type::LONG).to eq(10)
+
+    m.write :long, 10
+    expect(m.read :long).to eq(10)
+  end
+
+  it "allows writing as a size_t" do
+    m = FFI::MemoryPointer.new(:size_t)
+    m.write(:size_t, 10)
+    expect(m.read :size_t).to eq(10)
+  end
+
+  it "allows writing as a bool" do
+    m = FFI::MemoryPointer.new(:bool)
+    m.write(:bool, true)
+    expect(m.read :bool).to eq(true)
+    expect(m.read FFI::Type::BOOL).to eq(true)
+
+    m.write(:bool, false)
+    expect(m.read :bool).to eq(false)
+    expect(m.read FFI::Type::BOOL).to eq(false)
+  end
+
+  it "allows writing a custom typedef" do
+    FFI.typedef :uint, :fubar_t
+    FFI.typedef :size_t, :fubar2_t
+
+    m = FFI::MemoryPointer.new(:fubar_t)
+    m.write(:fubar_t, 10)
+    expect(m.read :fubar_t).to eq(10)
+
+    m = FFI::MemoryPointer.new(:fubar2_t)
+    m.write(:fubar2_t, 10)
+    expect(m.read :fubar2_t).to eq(10)
+  end
+
+  it "raises an error if you try to read an undefined type" do
+    m = FFI::MemoryPointer.new(:long)
+    expect { m.read(:undefined_type) }.to raise_error(ArgumentError)
   end
   
   it "raises an error if you try putting a long into a pointer of size 1" do


### PR DESCRIPTION
Similar to #472, but a cleaner and more general approach, IMHO.
These methods are especially useful for writing and reading to pointers of typedef'd types, such
as `size_t`.