### PR TITLE
Add Pointer#to_ptr

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -130,5 +130,10 @@ module FFI
       }
       self
     end
+
+    # @return [self]
+    def to_ptr
+      self
+    end
   end
 end

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -62,6 +62,13 @@ describe "Pointer" do
     expect { PointerTestLib.ptr_ret_int32(0xfee1deadbeefcafebabe, 0) }.to raise_error
   end
 
+  it "#to_ptr" do
+    memory = FFI::MemoryPointer.new :pointer
+    expect(memory.to_ptr).to eq(memory)
+
+    expect(FFI::Pointer::NULL.to_ptr).to eq(FFI::Pointer::NULL)
+  end
+
   describe "pointer type methods" do
 
     it "#read_pointer" do


### PR DESCRIPTION
This adds `Pointer#to_ptr`. It's there in JRuby, and particularly useful to assign struct pointers that 
can possibly be `NULL` to `:pointer` fields, i.e.:

```ruby
  struct_or_null = ...
  other_struct[:pointer_field] = struct_or_null.to_ptr
```

It turns out that the `ffi` gem let's you assign structs directly, without calling `to_ptr`. However, the
call is necessary in JRuby, BTW.