### PR TITLE
Create default call frame.

### DIFF
--- a/ext/ffi_c/Thread.c
+++ b/ext/ffi_c/Thread.c
@@ -344,9 +344,13 @@ thread_data_free(void *ptr)
 void
 rbffi_Thread_Init(VALUE moduleFFI)
 {
+    static rbffi_frame_t root_frame;
 #ifdef _WIN32
     frame_thread_key = TlsAlloc();
 #else
     pthread_key_create(&thread_data_key, thread_data_free);    
 #endif
+    /* Create a root frame for the thread initialising us.
+     * This makes programs that embed ruby work (see #527) */
+    rbffi_frame_push(&root_frame);
 }


### PR DESCRIPTION
Programs that embed Ruby and use FFI couldn't use FFI callbacks and
call them from the main program because callback_invoke() thought that
the calling thread doesn't have the gvl (even for single threaded programs),
because no call frame was found. There is none because the main program
calls the ruby directly without any ruby function inbetween, This resulted
in a deadlock.

Fixes #527
