### PR TITLE
Include uintptr_t type on x86_64-linux

### DIFF
--- a/lib/ffi/platform/x86_64-linux/types.conf
+++ b/lib/ffi/platform/x86_64-linux/types.conf
@@ -100,3 +100,4 @@ rbx.platform.typedef.rlim_t = ulong
 rbx.platform.typedef.__rlimit_resource_t = int
 rbx.platform.typedef.__rusage_who_t = int
 rbx.platform.typedef.__priority_which_t = int
+rbx.platform.typedef.uintptr_t = ulong


### PR DESCRIPTION
This was missing when using Vagrant 1.9.1 (on RHEL 7), ffi (1.9.14 rebuilt since bundled ffi in Vagrant 1.9.1 is linked wrong).