### PR TITLE
Use PRIsVALUE shim when not available for Ruby 1.9.3 compatibility.

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -49,6 +49,14 @@
 #include "Function.h"
 #include "LongDouble.h"
 
+#ifdef PRIsVALUE
+# define RB_OBJ_CLASSNAME(obj) rb_obj_class(obj)
+# define RB_OBJ_STRING(obj) (obj)
+#else
+# define PRIsVALUE "s"
+# define RB_OBJ_CLASSNAME(obj) rb_obj_classname(obj)
+# define RB_OBJ_STRING(obj) StringValueCStr(obj)
+#endif
 
 static inline char* memory_address(VALUE self);
 VALUE rbffi_AbstractMemoryClass = Qnil;


### PR DESCRIPTION
This fixes #547. It is inspired by https://github.com/ruby/ruby/commit/a1a237fb36d4b78548d2aa94f03a6c460e50b4a7 (also used in https://github.com/ruby/ruby/blob/ff3496b0116ed2ed589d000b7bfca3d8288b009c/ext/json/fbuffer/fbuffer.h#L28-L35).

*I'm not sure if defining of `RB_OBJ_CLASSNAME` is needed here.*

Currently, there's ruby `>= 1.8.7` `required_ruby_version` in gemspec. To support 1.8.7 we need to remove `rb_sprintf` usage also.

It will be nice to decide how to proceed before new version will be released:

1. drop < 2.0 support (change `required_ruby_version` to '>= 2.0.0' in gemspec)
2. merge this and support Ruby >= 1.9.3 (change `required_ruby_version` to '>= 1.9.3' in gemspec)
3. merge this + remove usage of `rb_sprintf` and support => 1.8.7