### PR TITLE
use latest rake-compiler-dock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'rake', '~> 10.1'
-  gem 'rake-compiler', '~> 0.9.5'
-  gem 'rake-compiler-dock', '~> 0.5.2'
+  gem 'rake-compiler'
+  gem 'rake-compiler-dock'
   gem 'rspec', '~> 3.0'
   gem 'rubygems-tasks', '~> 0.2.4', :require => 'rubygems/tasks'
   gem "rubysl", "~> 2.0", :platforms => 'rbx'


### PR DESCRIPTION
Ruby 2.4 requires rake-compiler-dock v0.6.0.
Moreover it should always use latest one because of tracking latest rubies.

## How to release a binary gem for newer Ruby for Windows

* Merge this pull request
* run `bundle update` to update the latest rake-compiler-dock, which should support latest Ruby
* bump the version (1.9.14 is already released. it needs to use new one)
* release Unix version with `rake release` or something usual.
* run `bundle exec rake gem:windows`
  * It needs docker. see https://github.com/rake-compiler/rake-compiler-dock#installation for the detail
  * On macOS,  `bundle exec rake gem:windows MACHINE_DRIVER=xhyve` is easy because it doesn’t need virtualbox
* gem push pkg/ffi-1.9.15-x86-mingw32.gem
* gem push pkg/ffi-1.9.15-x64-mingw32.gem