### PR TITLE
Avoid undefined behaviour of LoadLibrary() on Windows.

### DIFF
--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -185,7 +185,8 @@ dl_open(const char* name, int flags)
     if (name == NULL) {
         return GetModuleHandle(NULL);
     } else {
-        return LoadLibraryExA(name, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+        DWORD dwFlags = PathIsRelativeA(name) ? 0 : LOAD_WITH_ALTERED_SEARCH_PATH;
+        return LoadLibraryExA(name, NULL, dwFlags);
     }
 }
 


### PR DESCRIPTION
According to [1] the flag LOAD_WITH_ALTERED_SEARCH_PATH should be used with absolute paths only. It has the effect, that the path of the DLL to be loaded is temporary added to the search path, so that dependent DLLs in the same directory can be found and loaded implicit.

However for relative paths the standard LoadLibrary() search order should be used, because the behaviour of LOAD_WITH_ALTERED_SEARCH_PATH isn't defined for relative paths. In practice (on Windows 10) relative paths to Windows system DLLs do work, so that the library is loaded,
but DLLs in other search paths are not found, when this flag is set.

Ruby's fiddle library uses LoadLibrary without flags in both cases.

[1]
https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx