### PR TITLE
Tweaks for cross compiling with MSYS2 toolchain

### DIFF
--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -36,6 +36,7 @@
 # include <winsock2.h>
 # define _WINSOCKAPI_
 # include <windows.h>
+# include <shlwapi.h>
 #else
 # include <dlfcn.h>
 #endif

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -24,7 +24,8 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     # Check if the raw api is available.
     $defs << "-DHAVE_RAW_API" if have_func("ffi_raw_call") && have_func("ffi_prep_raw_closure")
   end
-  
+
+  have_header('shlwapi.h')
   have_func('rb_thread_blocking_region')
   have_func('rb_thread_call_with_gvl')
   have_func('rb_thread_call_without_gvl')

--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.require_paths << 'ext/ffi_c'
   s.required_ruby_version = '>= 1.8.7'
   s.add_development_dependency 'rake', '~> 10.1'
-  s.add_development_dependency 'rake-compiler', '~> 0.9'
-  s.add_development_dependency 'rake-compiler-dock', '~> 0.5.2'
+  s.add_development_dependency 'rake-compiler', '~> 1.0'
+  s.add_development_dependency 'rake-compiler-dock', '~> 0.6.0'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubygems-tasks', "~> 0.2.4"
 end


### PR DESCRIPTION
* Specify the latest rake-compiler and rake-compiler-dock in gemspec
* Fixes undefined reference for `PathIsRelativeA`

I've confirmed that `bundle exec rake gem:windows` generates fat gems:

```log
% bundle exec rake gem:windows
# take some time....
% ls pkg
ffi-1.9.17-x64-mingw32     ffi-1.9.17-x86-mingw32.gem
ffi-1.9.17-x64-mingw32.gem ffi-1.9.17.gem
ffi-1.9.17-x86-mingw32
```