### PR TITLE
Use `rb_gc_mark_values` for marking function parameters

### DIFF
--- a/ext/ffi_c/FunctionInfo.c
+++ b/ext/ffi_c/FunctionInfo.c
@@ -84,7 +84,7 @@ fntype_mark(FunctionType* fnInfo)
     rb_gc_mark(fnInfo->rbParameterTypes);
     rb_gc_mark(fnInfo->rbEnums);
     if (fnInfo->callbackCount > 0 && fnInfo->callbackParameters != NULL) {
-        rb_gc_mark_locations(&fnInfo->callbackParameters[0], &fnInfo->callbackParameters[fnInfo->callbackCount]);
+        rb_gc_mark_values(fnInfo->callbackCount, fnInfo->callbackParameters);
     }
 }
 


### PR DESCRIPTION
`rb_gc_mark_values` is more efficient than `rb_gc_mark_locations`.
`rb_gc_mark_locations` is typically used for marking addresses from the
stack.  This means that it must check to see if the pointer is a heap
pointer before marking it.  Since we already know the length of this
VALUE array, and that each pointer in the value array did indeed come
from the GC, we don't need to check whether or not the pointer is good
(because we already know it is).