### PR TITLE
Add support for MSYS2

### DIFF
--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -95,7 +95,7 @@ module FFI
     public
 
     LIBPREFIX = case OS
-    when /windows/
+    when /windows|msys/
       ''
     when /cygwin/
       'cyg'
@@ -108,7 +108,7 @@ module FFI
       'dylib'
     when /linux|bsd|solaris/
       'so'
-    when /windows|cygwin/
+    when /windows|cygwin|msys/
       'dll'
     else
       # Punt and just assume a sane unix (i.e. anything but AIX)
@@ -121,6 +121,9 @@ module FFI
       GNU_LIBC
     elsif OS == 'cygwin'
       "cygwin1.dll"
+    elsif OS == 'msys'
+      # Not sure how msys 1.0 behaves, tested on MSYS2.
+      "msys-2.0.dll"
     else
       "#{LIBPREFIX}c.#{LIBSUFFIX}"
     end


### PR DESCRIPTION
I'm not sure if anything else needs updated to work with MSYS2, but these changes made it work in an install of MSYS2 with the Ruby 2.3.3 package installed.