### PR TITLE
update travis for latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,15 @@ os:
   - linux
   - osx
 rvm:
-  - "1.9.3"
-  - "2.0.0"
-  - "2.1"
-  - "2.2.3"
-  - "2.3.0"
-  - "2.4.0"
-  - "ruby-head"
-  - "rbx"
-  - "system"
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - ruby-head
+  - rbx
+  - system
 env:
   - CC=gcc
   - CC=clang
@@ -28,8 +28,22 @@ matrix:
     - rvm: system
     - os: osx
       rvm: ruby-head
-    - rvm: "rbx"
-    - rvm: "rbx-head"
-    - rvm: "1.9.3"
+    - rvm: rbx
+    - rvm: rbx-head
+    - rvm: 1.9.3
+  exclude: # ruby 2.4.2 needs build with xcode9 or later on osx
+    - os: osx
+      rvm: 2.4.2
+  include:
+    - os: osx
+      osx_image: xcode9.1
+      rvm: 2.4.2
+      env:
+      - CC=gcc
+    - os: osx
+      osx_image: xcode9.1
+      rvm: 2.4.2
+      env:
+      - CC=clang
 after_failure:
   - "find build -name mkmf.log | xargs cat"


### PR DESCRIPTION
Updated to latest ruby versions, also removed unnecessary quotes.  Ruby-2.4.2 on OSX needs to be build with xcode9.1.  Ruby-2.0 and earlier fail to build if xcode9.1 is set on all builds, so I only applied it to the 2.4.2 builds.