### PR TITLE
Pointer#write_array_of_type did not work

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -124,10 +124,9 @@ module FFI
     #  ptr.write_array_of_type(TYPE_UINT8, :put_uint8, [1, 2, 3 ,4])
     def write_array_of_type(type, writer, ary)
       size = FFI.type_size(type)
-      tmp = self
-      ary.each_with_index {|i, j|
-        tmp.send(writer, i)
-        tmp += size unless j == ary.length-1 # avoid OOB
+      ary.each_with_index { |val, i|
+        break unless i < self.size
+        self.send(writer, i * size, val)
       }
       self
     end

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -94,7 +94,26 @@ describe "Pointer" do
         expect(array[j].address).to eq(address)
       end
     end
-    
+
+    it "#write_array_of_type for uint8" do
+      values = [10, 227, 32]
+      memory = FFI::MemoryPointer.new FFI::TYPE_UINT8, values.size
+      memory.write_array_of_type(FFI::TYPE_UINT8, :put_uint8, values)
+      array = memory.read_array_of_type(FFI::TYPE_UINT8, :read_uint8, values.size)
+      values.each_with_index do |val, j|
+        expect(array[j]).to eq(val)
+      end
+    end
+
+    it "#write_array_of_type for uint32" do
+      values = [10, 227, 32]
+      memory = FFI::MemoryPointer.new FFI::TYPE_UINT32, values.size
+      memory.write_array_of_type(FFI::TYPE_UINT32, :put_uint32, values)
+      array = memory.read_array_of_type(FFI::TYPE_UINT32, :read_uint32, values.size)
+      values.each_with_index do |val, j|
+        expect(array[j]).to eq(val)
+      end
+    end
   end
 
   describe 'NULL' do


### PR DESCRIPTION
The following example that is written in comments of Pointer#write_array_of_type did not work.

    ptr.write_array_of_type(TYPE_UINT8, :put_uint8, [1, 2, 3 ,4])

I fixed it and made test for it.
Would you consider merging these commits?