### PR TITLE
Adding MacPorts,Fink,etc search path to /opt/local/lib

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -126,7 +126,7 @@ module FFI
               else
                 # TODO better library lookup logic
                 unless libname.start_with?("/") || FFI::Platform.windows?
-                  path = ['/usr/lib/','/usr/local/lib/'].find do |pth|
+                  path = ['/usr/lib/','/usr/local/lib/','/opt/local/lib/'].find do |pth|
                     File.exist?(pth + libname)
                   end
                   if path


### PR DESCRIPTION
Currently any projects relying on package manager MacPorts and Fink unable to load libraries due to search path. By adding search path for `/opt/local/lib` will resolve this issue and many other ruby libraries using FFI.

Error example:
`LoadError: Could not open library 'glib-2.0': dlopen(glib-2.0, 5): image not found.`