### PR TITLE
Replaced :get_uint8 with :read_uint8 in Pointer#read_array_of_type documentation

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -103,7 +103,7 @@ module FFI
     # @return [Array]
     # Read an array of +type+ of length +length+.
     # @example
-    #  ptr.read_array_of_type(TYPE_UINT8, :get_uint8, 4) # -> [1, 2, 3, 4]
+    #  ptr.read_array_of_type(TYPE_UINT8, :read_uint8, 4) # -> [1, 2, 3, 4]
     def read_array_of_type(type, reader, length)
       ary = []
       size = FFI.type_size(type)


### PR DESCRIPTION
The documentation of Pointer#read_array_of_type states that I should pass `:get_uint8` to it, but actually it should be `:read_uint8`, because `:get_uint8` would fail with `ArgumentError: wrong number of arguments (given 0, expected 1)` 

This PR is actually fixes #266 which is closed, but not fixed (from 2013!)