### PR TITLE
Add tests on armhf and ppc64le linux, JRuby and Truffleruby on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,20 @@ matrix:
     - os: osx
       rvm: 2.4.2
   include:
+    - name: powerpc
+      language: generic
+      before_install: |
+        docker run --rm --privileged multiarch/qemu-user-static:register --reset &&
+          docker build --rm -t ffi-powerpc -f spec/env/Dockerfile.powerpc .
+      script: |
+        docker run --rm -t -v `pwd`:/ffi ffi-powerpc
+    - name: armhf
+      language: generic
+      before_install: |
+        docker run --rm --privileged multiarch/qemu-user-static:register --reset &&
+          docker build --rm -t ffi-armhf -f spec/env/Dockerfile.armhf .
+      script: |
+        docker run --rm -t -v `pwd`:/ffi ffi-armhf
     - os: osx
       osx_image: xcode9.1
       rvm: 2.4.2

--- a/spec/env/Dockerfile.armhf
+++ b/spec/env/Dockerfile.armhf
@@ -1,0 +1,25 @@
+# See .travis.yml how this docker image can be used.
+FROM multiarch/ubuntu-debootstrap:armhf-bionic
+
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq \
+    autoconf \
+    automake \
+    file \
+    gcc \
+    git \
+    libtool \
+    make \
+    ruby-dev
+RUN ruby --version
+
+WORKDIR /ffi
+COPY . .
+
+RUN gem install bundler --no-doc && \
+    bundle install
+
+CMD bundle install && \
+    bundle exec rake compile && \
+    bundle exec rake test

--- a/spec/env/Dockerfile.powerpc
+++ b/spec/env/Dockerfile.powerpc
@@ -1,0 +1,25 @@
+# See .travis.yml how this docker image can be used.
+FROM multiarch/ubuntu-debootstrap:powerpc-xenial
+
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq \
+    autoconf \
+    automake \
+    file \
+    gcc \
+    git \
+    libtool \
+    make \
+    ruby-dev
+RUN ruby --version
+
+WORKDIR /ffi
+COPY . .
+
+RUN gem install bundler --no-doc && \
+    bundle install
+
+CMD bundle install && \
+    bundle exec rake compile && \
+    bundle exec rake test


### PR DESCRIPTION
CI testing is currently done on Windows-x86, Windows-x64, Linux-x86_64 and MacOS-x86_64.
This adds PPC64le and ARMv7 by using docker and qemu.

This also adds JRuby and Truffleruby, so that we notify the differences to them. They currently fail, but the aim is to fix JRuby and Truffleruby support in the future.