### PR TITLE
CI: Skip superfluous gem install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 dist: trusty
-sudo: false
 group: beta
 language: ruby
-before_install:
-  - gem install bundler
+
 script:
   - bundle exec rake compile || bundle exec rake compile
   - bundle exec rake test


### PR DESCRIPTION
This PR is here to keep the Travis configuration file simpler.

 - `gem install bundler` is done after rvm has installed a bundler (this is true for each of the Rubies in the matrix)
  - Remove outdated `sudo: false` Travis directive