### PR TITLE
CI: Drop "system" ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,12 @@ rvm:
   - 2.5.3
   - 2.6.0
   - ruby-head
-  - system
+
 env:
   - CC=gcc
   - CC=clang
 matrix:
   allow_failures:
-    - rvm: system
     - os: osx
       rvm: ruby-head
   exclude: # ruby 2.4.2 needs build with xcode9 or later on osx


### PR DESCRIPTION
This PR reduces the size of the CI matrix by removing `system`.

  - its file location for gems is not even writable, so it fails to install
  - it does not represent any new Ruby version which does not already exist in the matrix