### PR TITLE
make benchmarks run

### DIFF
--- a/bench/bench_FFFrV.rb
+++ b/bench/bench_FFFrV.rb
@@ -22,25 +22,3 @@ puts "Benchmark ruby method(1 arg)  performance, #{ITER}x calls"
     ITER.times { LibTest.rb_bench(f, f, f) }
   }
 }
-
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void bench_f32f32f32_v(float, float, float)"
-  end
-  puts "Benchmark DL void bench(float, float, float) performance, #{ITER}x calls"
-  10.times {
-  f1 = 1.0; f2 = 2.0; f3 = 3.0
-    puts Benchmark.measure {
-      ITER.times { LibTest.bench_f32f32f32_v(f1, f2, f3) }
-    }
-  }
-end
-

--- a/bench/bench_FrV.rb
+++ b/bench/bench_FrV.rb
@@ -34,30 +34,3 @@ puts "Benchmark ruby method(1 arg)  performance, #{ITER}x calls"
     end
   }
 }
-
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void bench_f32_v(float)"
-  end
-  puts "Benchmark DL void bench(float) performance, #{ITER}x calls"
-  10.times {
-    puts Benchmark.measure {
-      i = 0; while i < ITER
-        LibTest.bench_f32_v(0)
-        LibTest.bench_f32_v(0)
-        LibTest.bench_f32_v(0)
-        LibTest.bench_f32_v(0)
-        i += 4
-      end
-    }
-  }
-end
-

--- a/bench/bench_IIIIIIrV.rb
+++ b/bench/bench_IIIIIIrV.rb
@@ -1,12 +1,11 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
-METHOD = 'bench_s32s32s32s32s32s32_v'
+
 module LibTest
   extend FFI::Library
   ffi_lib LIBTEST_PATH
-  attach_function :ffi_bench, METHOD, [ :int, :int, :int, :int, :int, :int ], :void, :save_errno => false
+  attach_function :ffi_bench, 'bench_s32s32s32s32s32s32_v', [ :int, :int, :int, :int, :int, :int ], :void, :save_errno => false
   def self.rb_bench(i0, i1, i2, i3, i4, i5); nil; end
 end
-
 
 puts "Benchmark [ :int, :int, :int, :int, :int, :int ], :void performance, #{ITER}x calls"
 10.times {
@@ -27,27 +26,4 @@ puts "Benchmark ruby method(6 arg)  performance, #{ITER}x calls"
     end
   }
 }
-
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void bench_s32s32s32s32s32s32_v(int, int, int, int, int, int)"
-  end
-  puts "Benchmark DL void bench(int, int, int) performance, #{ITER}x calls"
-  10.times {
-    puts Benchmark.measure {
-      i = 0; while i < ITER
-        LibTest.bench_s32s32s32s32s32s32_v(0, 1, 2, 3, 4, 5)
-        i += 1
-      end
-    }
-  }
-end
 

--- a/bench/bench_IIIrV.rb
+++ b/bench/bench_IIIrV.rb
@@ -7,21 +7,6 @@ module LibTest
   def self.rb_bench(i0, i1, i2); nil; end
 end
 
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void bench_s32s32s32_v(int, int, int)"
-  end
-end
-
-
 puts "Benchmark [ :int, :int, :int ], :void performance, #{ITER}x calls"
 10.times {
   puts Benchmark.measure {
@@ -41,15 +26,3 @@ puts "Benchmark ruby method(3 arg)  performance, #{ITER}x calls"
     end
   }
 }
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-puts "Benchmark DL void bench(int, int, int) performance, #{ITER}x calls"
-10.times {
-  puts Benchmark.measure {
-    i = 0; while i < ITER
-      LibTest.bench_s32s32s32_v(0, 1, 2)
-      i += 1
-    end
-  }
-}
-end
-

--- a/bench/bench_IrV.rb
+++ b/bench/bench_IrV.rb
@@ -6,19 +6,6 @@ module LibTest
   attach_function :ffi_bench, :bench_s32_v, [ :int ], :void, :save_errno => false
   def self.rb_bench(i0); nil; end
 end
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void bench_s32_v(int)"
-  end
-end
 
 puts "Benchmark [ :int ], :void performance, #{ITER}x calls"
 10.times {
@@ -45,17 +32,3 @@ puts "Benchmark ruby method(1 arg)  performance, #{ITER}x calls"
     end
   }
 }
-
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-puts "Benchmark DL void bench(int) performance, #{ITER}x calls"
-10.times {
-  puts Benchmark.measure {
-    i = 0; while i < ITER
-      LibTest.bench_s32_v(0)
-      i += 1
-    end
-  }
-}
-end
-
-

--- a/bench/bench_VrI.rb
+++ b/bench/bench_VrI.rb
@@ -7,20 +7,6 @@ module LibTest
   def self.rb_bench; 0xdeadbeef; end
 end
 
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "int returnInt()"
-  end
-end
-
 puts "Benchmark [ ], :int performance, #{ITER}x calls"
 10.times {
   puts Benchmark.measure {
@@ -48,19 +34,3 @@ puts "Benchmark ruby method(), nil performance, #{ITER}x calls"
     end
   }
 }
-
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-puts "Benchmark DL void bench() performance, #{ITER}x calls"
-10.times {
-  puts Benchmark.measure {
-    i = 0; max = ITER / 4
-    while i < max
-      LibTest.returnInt
-      LibTest.returnInt
-      LibTest.returnInt
-      LibTest.returnInt
-      i += 1
-    end
-  }
-}
-end

--- a/bench/bench_VrV.rb
+++ b/bench/bench_VrV.rb
@@ -8,20 +8,6 @@ module LibTest
   def self.rb_bench; nil; end
 end
 
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void returnVoid()"
-  end
-end
-
 puts "Benchmark [ ], :void performance, #{ITER}x calls"
 10.times {
   puts Benchmark.measure {
@@ -32,20 +18,6 @@ puts "Benchmark [ ], :void performance, #{ITER}x calls"
     end
   }
 }
-
-
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-puts "Benchmark DL void bench() performance, #{ITER}x calls"
-10.times {
-  puts Benchmark.measure {
-    i = 0
-    while i < ITER
-      LibTest.returnVoid
-      i += 1
-    end
-  }
-}
-end
 
 puts "Benchmark [ ], :void no-errno performance, #{ITER}x calls"
 10.times {

--- a/bench/bench_closure_IIIrV.rb
+++ b/bench/bench_closure_IIIrV.rb
@@ -7,19 +7,6 @@ module LibTest
   attach_function :ffi_bench, :testClosureIIIrV, [ :closureIIIrV, :int, :int, :int ], :void
   def self.rb_bench(a, b, c, &block); yield(a, b, c); end
 end
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "int returnInt()"
-  end
-end
 
 class Foo
   def call(a, b, c); nil; end
@@ -71,15 +58,6 @@ puts "Benchmark [ ], :void pre-allocated callable, #{ITER}x calls"
     ITER.times { LibTest.ffi_bench(proc, 1, 2, 3) }
   }
 }
-
-#unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-#puts "Benchmark DL void bench() performance, #{ITER}x calls"
-#10.times {
-#  puts Benchmark.measure {
-#    ITER.times { LibTest.returnInt }
-#  }
-#}
-#end
 
 puts "Benchmark ruby method(3 arg), #{ITER}x calls"
 10.times {

--- a/bench/bench_closure_IrV.rb
+++ b/bench/bench_closure_IrV.rb
@@ -7,19 +7,6 @@ module LibTest
   attach_function :ffi_bench, :testClosureIrV, [ :closureVrV, :int ], :void
   def self.rb_bench(i, &block); nil; end
 end
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "int returnInt()"
-  end
-end
 
 puts "Benchmark [ ], :void closure block performance, #{ITER}x calls"
 10.times {

--- a/bench/bench_closure_VrV.rb
+++ b/bench/bench_closure_VrV.rb
@@ -14,20 +14,6 @@ module LibTest
   end
 end
 
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "int returnInt()"
-  end
-end
-
 puts "Benchmark [ ], :void closure block performance, #{ITER}x calls"
 10.times {
   puts Benchmark.measure {
@@ -58,16 +44,6 @@ puts "Benchmark [ ], :void non-ruby thread closure performance, #{ITER}x calls"
     LibTest.threaded_bench(fn, ITER)
   }
 }
-
-
-#unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-#puts "Benchmark DL void bench() performance, #{ITER}x calls"
-#10.times {
-#  puts Benchmark.measure {
-#    ITER.times { LibTest.returnInt }
-#  }
-#}
-#end
 
 puts "Benchmark ruby method(no arg)  performance, #{ITER}x calls"
 10.times {

--- a/bench/bench_enum.rb
+++ b/bench/bench_enum.rb
@@ -29,25 +29,13 @@ puts "Benchmark [ :int ], :void performance, #{ITER}x calls"
     ITER.times { LibTest.ffi_bench_i(1) }
   }
 }
+
 puts "Benchmark [ :int ], :void with enum arg performance, #{ITER}x calls"
 10.times {
   puts Benchmark.measure {
     ITER.times { LibTest.ffi_bench_i(:a) }
   }
 }
-unless RUBY_PLATFORM == "java" && JRUBY_VERSION < "1.3.0"
-  require 'dl'
-  require 'dl/import'
-  module LibTest
-    if RUBY_VERSION >= "1.9.0"
-      extend DL::Importer
-    else
-      extend DL::Importable
-    end
-    dlload LIBTEST_PATH
-    extern "void bench_s32_v(int)"
-  end
-end
 
 puts "Benchmark ruby method(1 arg)  performance, #{ITER}x calls"
 10.times {


### PR DESCRIPTION
Removes the `ruby/dl` references from the benchmarks so they run.