### PR TITLE
Fix benchmarks and harness, compile libtest automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: ruby
 script:
   - bundle exec rake compile || bundle exec rake compile
   - bundle exec rake test
+  - ITER=10 bundle exec rake bench:all
 os:
   - linux
   - osx

--- a/Rakefile
+++ b/Rakefile
@@ -56,8 +56,8 @@ task :test => [ :spec ]
 
 namespace :bench do
   ITER = ENV['ITER'] ? ENV['ITER'].to_i : 100000
-  bench_libs = "-Ilib -I#{BUILD_DIR}" unless RUBY_PLATFORM == "java"
-  bench_files = Dir["bench/bench_*.rb"].reject { |f| f == "bench_helper.rb" }
+  bench_libs = "-Ilib -I#{BUILD_EXT_DIR}" unless RUBY_PLATFORM == "java"
+  bench_files = Dir["bench/bench_*.rb"].reject { |f| f == "bench/bench_helper.rb" }
   bench_files.each do |bench|
     task File.basename(bench, ".rb")[6..-1] => TEST_DEPS do
       sh %{#{Gem.ruby} #{bench_libs} #{bench} #{ITER}}

--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ task :test => [ :spec ]
 
 namespace :bench do
   ITER = ENV['ITER'] ? ENV['ITER'].to_i : 100000
-  bench_libs = "-Ilib -I#{BUILD_EXT_DIR}" unless RUBY_PLATFORM == "java"
+  bench_libs = "-Ilib" unless RUBY_PLATFORM == "java"
   bench_files = Dir["bench/bench_*.rb"].reject { |f| f == "bench/bench_helper.rb" }
   bench_files.each do |bench|
     task File.basename(bench, ".rb")[6..-1] => TEST_DEPS do

--- a/bench/bench_FFFrV.rb
+++ b/bench/bench_FFFrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_FrV.rb
+++ b/bench/bench_FrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_IIIIIIrV.rb
+++ b/bench/bench_IIIIIIrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_IIIrI.rb
+++ b/bench/bench_IIIrI.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_IIIrI.rb
+++ b/bench/bench_IIIrI.rb
@@ -7,11 +7,9 @@ module LibTest
 end
 
 
-puts "Benchmark [ :int, :int, :int ], :void performance, #{ITER}x calls"
-
+puts "Benchmark [ :int, :int, :int ], :int performance, #{ITER}x calls"
 10.times {
   puts Benchmark.measure {
     ITER.times { LibTest.bench(0, 1, 2) }
   }
 }
-puts "Benchmark Invoker.call [ :int, :int, :int ], :void performance, #{ITER}x calls"

--- a/bench/bench_IIIrV.rb
+++ b/bench/bench_IIIrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_IrV.rb
+++ b/bench/bench_IrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_LLLrV.rb
+++ b/bench/bench_LLLrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_PPPrV.rb
+++ b/bench/bench_PPPrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_PPrV.rb
+++ b/bench/bench_PPrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_PrV.rb
+++ b/bench/bench_PrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_SrV.rb
+++ b/bench/bench_SrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_VrI.rb
+++ b/bench/bench_VrI.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_VrV.rb
+++ b/bench/bench_VrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_autoptr.rb
+++ b/bench/bench_autoptr.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 class Ptr < FFI::AutoPointer
@@ -16,7 +14,7 @@ module LibC
   attach_function :malloc, [ :long ], Ptr, :ignore_error => true
   attach_function :malloc2, :malloc, [ :long ], :pointer, :ignore_error => true
   attach_function :free, [ :pointer ], :void, :ignore_error => true
-  def self.finalizer(ptr) 
+  def self.finalizer(ptr)
     proc { LibC.free(ptr) }
   end
 end
@@ -32,11 +30,10 @@ puts "Benchmark AutoPointer.new performance, #{iter}x"
 puts "Benchmark ObjectSpace finalizer performance, #{iter}x"
 10.times {
   puts Benchmark.measure {
-    iter.times { 
+    iter.times {
       ptr = LibC.malloc2(4)
       ptr2 = FFI::Pointer.new(ptr)
       ObjectSpace.define_finalizer(ptr2, LibC.finalizer(ptr))
     }
   }
 }
-

--- a/bench/bench_buffer.rb
+++ b/bench/bench_buffer.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 module BufferBench
@@ -109,4 +107,3 @@ puts "Benchmark FFI call(Buffer.alloc_out(4, 1, true)) performance, #{iter}x"
     iter.times { BufferBench.bench_buffer_out(FFI::Buffer.alloc_out(4, 1, true), 0) }
   }
 }
-

--- a/bench/bench_buffer_alloc.rb
+++ b/bench/bench_buffer_alloc.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 puts "Benchmark Buffer.new(:int, 1, true)) performance, #{iter}x"
@@ -43,4 +41,3 @@ puts "Benchmark Buffer.new(256, 1, true)) performance, #{iter}x"
     end
   }
 }
-

--- a/bench/bench_buffer_fill.rb
+++ b/bench/bench_buffer_fill.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 puts "Benchmark Buffer#put_array_of_float performance, #{iter}x"
@@ -9,7 +7,7 @@ puts "Benchmark Buffer#put_array_of_float performance, #{iter}x"
 5.times {
   ptr = FFI::Buffer.new(:float, 8, false)
   puts Benchmark.measure {
-    iter.times { 
+    iter.times {
       ptr.put_array_of_float(0, [ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8 ])
     }
   }
@@ -19,7 +17,7 @@ puts "Benchmark Buffer#put_array_of_float performance, #{iter}x"
 puts "Benchmark Buffer.new(:float, 8, false)).put_array_of_float performance, #{iter}x"
 5.times {
   puts Benchmark.measure {
-    iter.times { 
+    iter.times {
       ptr = FFI::Buffer.new(:float, 8, false)
       ptr.put_array_of_float(0, [ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8 ])
     }

--- a/bench/bench_chmod.rb
+++ b/bench/bench_chmod.rb
@@ -1,8 +1,6 @@
-require 'benchmark'
-require 'ffi'
-require 'ffi/platform'
+require_relative 'bench_helper'
 
-iter = 10_000
+iter = ITER
 file = "README"
 
 module Posix

--- a/bench/bench_closure_IIIrV.rb
+++ b/bench/bench_closure_IIIrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library
@@ -65,4 +65,3 @@ puts "Benchmark ruby method(3 arg), #{ITER}x calls"
     ITER.times { LibTest.rb_bench(1, 2, 3) {} }
   }
 }
-

--- a/bench/bench_closure_IrV.rb
+++ b/bench/bench_closure_IrV.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library
@@ -37,4 +37,3 @@ puts "Benchmark ruby method(1 arg)  performance, #{ITER}x calls"
     ITER.times { LibTest.rb_bench(1) {} }
   }
 }
-

--- a/bench/bench_closure_VrV.rb
+++ b/bench/bench_closure_VrV.rb
@@ -1,14 +1,14 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library
   ffi_lib LIBTEST_PATH
   callback :closureVrV, [ ], :void
-  
+
   attach_function :ffi_bench, :testClosureVrV, [ :closureVrV ], :void
   @blocking = true
   attach_function :threaded_bench, :testThreadedClosureVrV, [ :closureVrV, :int ], :void
-  
+
   def self.rb_bench(&block)
     yield
   end
@@ -51,4 +51,3 @@ puts "Benchmark ruby method(no arg)  performance, #{ITER}x calls"
     ITER.times { LibTest.rb_bench {} }
   }
 }
-

--- a/bench/bench_enum.rb
+++ b/bench/bench_enum.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library
@@ -43,4 +43,3 @@ puts "Benchmark ruby method(1 arg)  performance, #{ITER}x calls"
     ITER.times { LibTest.rb_bench(:a) }
   }
 }
-

--- a/bench/bench_enum_i.rb
+++ b/bench/bench_enum_i.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module LibTest
   extend FFI::Library

--- a/bench/bench_getlogin.rb
+++ b/bench/bench_getlogin.rb
@@ -1,8 +1,7 @@
-require 'benchmark'
-require 'ffi'
+require_relative 'bench_helper'
 require 'etc'
 
-iter = 1000000
+iter = ITER
 
 module Posix
   extend FFI::Library
@@ -13,7 +12,7 @@ if Posix.getlogin != Etc.getlogin
   raise ArgumentError, "FFI getlogin returned incorrect value"
 end
 
-puts "Benchmark FFI getlogin(2) performance, #{iter}x"
+puts "Benchmark FFI getlogin(2) performance, #{ITER}x"
 
 10.times {
   puts Benchmark.measure {
@@ -21,7 +20,7 @@ puts "Benchmark FFI getlogin(2) performance, #{iter}x"
   }
 }
 
-puts "Benchmark Etc.getlogin performance, #{iter}x"
+puts "Benchmark Etc.getlogin performance, #{ITER}x"
 10.times {
   puts Benchmark.measure {
     iter.times { Etc.getlogin }

--- a/bench/bench_getpid.rb
+++ b/bench/bench_getpid.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 iter = ITER
 

--- a/bench/bench_gettimeofday.rb
+++ b/bench/bench_gettimeofday.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module Posix
   extend FFI::Library

--- a/bench/bench_getuid.rb
+++ b/bench/bench_getuid.rb
@@ -1,7 +1,6 @@
-require 'benchmark'
-require 'ffi'
+require_relative 'bench_helper'
 
-iter = 100000
+iter = ITER
 
 module Posix
   extend FFI::Library

--- a/bench/bench_helper.rb
+++ b/bench/bench_helper.rb
@@ -10,6 +10,8 @@ end
 $LOAD_PATH.unshift(lib)
 require 'ffi'
 
+require_relative '../spec/ffi/fixtures/compile'
+
 ITER = ENV['ITER'] ? ENV['ITER'].to_i : 100_000
 
-LIBTEST_PATH = File.expand_path("../../spec/ffi/fixtures/libtest.#{FFI::Platform::LIBSUFFIX}", __FILE__)
+LIBTEST_PATH = TestLibrary::PATH

--- a/bench/bench_helper.rb
+++ b/bench/bench_helper.rb
@@ -1,8 +1,9 @@
 require 'benchmark'
+require 'rbconfig'
 
 lib = File.expand_path('../../lib', __FILE__)
 
-cext = "#{lib}/ffi_c.so"
+cext = "#{lib}/ffi_c.#{RbConfig::CONFIG['DLEXT']}"
 unless File.exist?(cext)
   abort "#{cext} is not compiled. Compile it with 'rake compile' first."
 end

--- a/bench/bench_helper.rb
+++ b/bench/bench_helper.rb
@@ -1,6 +1,13 @@
 require 'benchmark'
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+lib = File.expand_path('../../lib', __FILE__)
+
+cext = "#{lib}/ffi_c.so"
+unless File.exist?(cext)
+  abort "#{cext} is not compiled. Compile it with 'rake compile' first."
+end
+
+$LOAD_PATH.unshift(lib)
 require 'ffi'
 
 ITER = ENV['ITER'] ? ENV['ITER'].to_i : 100_000

--- a/bench/bench_helper.rb
+++ b/bench/bench_helper.rb
@@ -1,6 +1,8 @@
-require "rubygems"
-#require 'ffi/times' if RUBY_PLATFORM =~ /java/
 require 'benchmark'
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ffi'
-ITER = ENV['ITER'] ? ENV['ITER'].to_i : 100000
+
+ITER = ENV['ITER'] ? ENV['ITER'].to_i : 100_000
+
 LIBTEST_PATH = File.expand_path("../../spec/ffi/fixtures/libtest.#{FFI::Platform::LIBSUFFIX}", __FILE__)

--- a/bench/bench_math.rb
+++ b/bench/bench_math.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module FFIMath
   extend FFI::Library

--- a/bench/bench_memptr_alloc.rb
+++ b/bench/bench_memptr_alloc.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 module LibC
@@ -54,9 +52,8 @@ end
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
   require 'java'
   puts "calling java gc"
-  10.times { 
-    java.lang.System.gc 
+  10.times {
+    java.lang.System.gc
     sleep 1
   }
 end
-

--- a/bench/bench_memptr_fill.rb
+++ b/bench/bench_memptr_fill.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 puts "Benchmark MemoryPointer#put_array_of_float performance, #{iter}x"
@@ -9,7 +7,7 @@ puts "Benchmark MemoryPointer#put_array_of_float performance, #{iter}x"
 5.times {
   ptr = FFI::MemoryPointer.new(:float, 8, false)
   puts Benchmark.measure {
-    iter.times { 
+    iter.times {
       ptr.put_array_of_float(0, [ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8 ])
     }
   }
@@ -19,7 +17,7 @@ puts "Benchmark MemoryPointer#put_array_of_float performance, #{iter}x"
 puts "Benchmark MemoryPointer.new(:float, 8, false)).put_array_of_float performance, #{iter}x"
 5.times {
   puts Benchmark.measure {
-    iter.times { 
+    iter.times {
       ptr = FFI::MemoryPointer.new(:float, 8, false)
       ptr.put_array_of_float(0, [ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8 ])
     }

--- a/bench/bench_strlen.rb
+++ b/bench/bench_strlen.rb
@@ -1,4 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
+
 module LibC
   extend FFI::Library
   ffi_lib 'c'
@@ -23,4 +24,3 @@ puts "Benchmark FFI api strlen(3), with new string performance, #{ITER}x"
     ITER.times { LibC.strlen('test' * 10) }
   }
 }
-

--- a/bench/bench_struct.rb
+++ b/bench/bench_struct.rb
@@ -1,7 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
-
-require 'benchmark'
-require 'ffi'
+require_relative 'bench_helper'
 
 module StructBench
   extend FFI::Library

--- a/bench/bench_struct_field.rb
+++ b/bench/bench_struct_field.rb
@@ -1,7 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
 iter = ITER
 
 class TestStruct < FFI::Struct

--- a/bench/bench_struct_size.rb
+++ b/bench/bench_struct_size.rb
@@ -1,8 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
-require 'benchmark'
-require 'ffi'
-iter = ITER || 1000_000
+iter = ITER
 
 class TestStruct < FFI::Struct
   layout :i, :int, :p, :pointer
@@ -30,4 +28,3 @@ layout = TestStruct.layout
     iter.times { layout.size }
   }
 }
-

--- a/bench/bench_time.rb
+++ b/bench/bench_time.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module Posix
   extend FFI::Library

--- a/bench/bench_umask.rb
+++ b/bench/bench_umask.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "bench_helper"))
+require_relative 'bench_helper'
 
 module Posix
   extend FFI::Library

--- a/lib/ffi/types.rb
+++ b/lib/ffi/types.rb
@@ -152,7 +152,7 @@ module FFI
   # also allow to work with the pointer itself. This is useful when you want
   # a Ruby string already containing a copy of the data, but also the pointer
   # to the data for you to do something with it, like freeing it, in case the
-  # library handed the memory to off to the caller (Ruby-FFI).
+  # library handed the memory off to the caller (Ruby-FFI).
   #
   # It's {typedef}'d as +:strptr+.
   class StrPtrConverter

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -7,62 +7,62 @@ require 'rbconfig'
 require 'fileutils'
 require 'ffi'
 
-CPU = case RbConfig::CONFIG['host_cpu'].downcase
-  when /i[3456]86/
-    # Darwin always reports i686, even when running in 64bit mode
-    if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
-      "x86_64"
-    else
-      "i386"
-    end
-  when /amd64|x86_64/
-    "x86_64"
-  when /ppc64|powerpc64/
-    "powerpc64"
-  when /ppc|powerpc/
-    "powerpc"
-  when /^arm/
-    "arm"
-  else
-    RbConfig::CONFIG['host_cpu']
-  end
-
-OS = case RbConfig::CONFIG['host_os'].downcase
-  when /linux/
-    "linux"
-  when /darwin/
-    "darwin"
-  when /freebsd/
-    "freebsd"
-  when /openbsd/
-    "openbsd"
-  when /sunos|solaris/
-    "solaris"
-  when /mswin|mingw/
-    "win32"
-  else
-    RbConfig::CONFIG['host_os'].downcase
-  end
-
-def compile_library(path, lib)
-  dir = File.expand_path(path, File.dirname(__FILE__))
-  lib = "#{dir}/#{lib}"
-  unless File.exist?(lib)
-    output = nil
-    FileUtils.cd(dir) do
-      make = system('which gmake >/dev/null') ? 'gmake' : 'make'
-      output = system(*%{#{make} CPU=#{CPU} OS=#{OS}}.tap{|x| puts x.inspect})
-    end
-
-    unless $?.success?
-      puts "ERROR:\n#{output}"
-      raise "Unable to compile #{lib.inspect}"
-    end
-  end
-
-  lib
-end
-
 module TestLibrary
+  CPU = case RbConfig::CONFIG['host_cpu'].downcase
+    when /i[3456]86/
+      # Darwin always reports i686, even when running in 64bit mode
+      if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
+        "x86_64"
+      else
+        "i386"
+      end
+    when /amd64|x86_64/
+      "x86_64"
+    when /ppc64|powerpc64/
+      "powerpc64"
+    when /ppc|powerpc/
+      "powerpc"
+    when /^arm/
+      "arm"
+    else
+      RbConfig::CONFIG['host_cpu']
+    end
+
+  OS = case RbConfig::CONFIG['host_os'].downcase
+    when /linux/
+      "linux"
+    when /darwin/
+      "darwin"
+    when /freebsd/
+      "freebsd"
+    when /openbsd/
+      "openbsd"
+    when /sunos|solaris/
+      "solaris"
+    when /mswin|mingw/
+      "win32"
+    else
+      RbConfig::CONFIG['host_os'].downcase
+    end
+
+  def self.compile_library(path, lib)
+    dir = File.expand_path(path, File.dirname(__FILE__))
+    lib = "#{dir}/#{lib}"
+    unless File.exist?(lib)
+      output = nil
+      FileUtils.cd(dir) do
+        make = system('which gmake >/dev/null') ? 'gmake' : 'make'
+        output = system(*%{#{make} CPU=#{CPU} OS=#{OS}}.tap{|x| puts x.inspect})
+      end
+
+      unless $?.success?
+        puts "ERROR:\n#{output}"
+        raise "Unable to compile #{lib.inspect}"
+      end
+    end
+
+    lib
+  end
+
   PATH = compile_library(".", "libtest.#{FFI::Platform::LIBSUFFIX}")
 end

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -5,6 +5,7 @@
 
 require 'rbconfig'
 require 'fileutils'
+require 'ffi'
 
 CPU = case RbConfig::CONFIG['host_cpu'].downcase
   when /i[3456]86/
@@ -61,8 +62,6 @@ def compile_library(path, lib)
 
   lib
 end
-
-require 'ffi/platform'
 
 module TestLibrary
   PATH = compile_library(".", "libtest.#{FFI::Platform::LIBSUFFIX}")

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -14,19 +14,14 @@ CPU = case RbConfig::CONFIG['host_cpu'].downcase
     else
       "i386"
     end
-
   when /amd64|x86_64/
     "x86_64"
-
   when /ppc64|powerpc64/
     "powerpc64"
-
   when /ppc|powerpc/
     "powerpc"
-
   when /^arm/
     "arm"
-
   else
     RbConfig::CONFIG['host_cpu']
   end
@@ -51,15 +46,16 @@ OS = case RbConfig::CONFIG['host_os'].downcase
 def compile_library(path, lib)
   dir = File.expand_path(path, File.dirname(__FILE__))
   lib = "#{dir}/#{lib}"
-  if !File.exist?(lib)
+  unless File.exist?(lib)
     output = nil
     FileUtils.cd(dir) do
-      output = system(*%{#{system('which gmake >/dev/null') && 'gmake' || 'make'} CPU=#{CPU} OS=#{OS} }.tap{|x| puts x.inspect})
+      make = system('which gmake >/dev/null') ? 'gmake' : 'make'
+      output = system(*%{#{make} CPU=#{CPU} OS=#{OS}}.tap{|x| puts x.inspect})
     end
 
-    if $?.exitstatus != 0
+    unless $?.success?
       puts "ERROR:\n#{output}"
-      raise "Unable to compile \"#{lib}\""
+      raise "Unable to compile #{lib.inspect}"
     end
   end
 

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -62,6 +62,8 @@ def compile_library(path, lib)
   lib
 end
 
+require 'ffi/platform'
+
 module TestLibrary
-  PATH = compile_library(".", "libtest.#{RbConfig::CONFIG['DLEXT']}")
+  PATH = compile_library(".", "libtest.#{FFI::Platform::LIBSUFFIX}")
 end

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -1,0 +1,71 @@
+#
+# This file is part of ruby-ffi.
+# For licensing, see LICENSE.SPECS
+#
+
+require 'rbconfig'
+require 'fileutils'
+
+CPU = case RbConfig::CONFIG['host_cpu'].downcase
+  when /i[3456]86/
+    # Darwin always reports i686, even when running in 64bit mode
+    if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
+      "x86_64"
+    else
+      "i386"
+    end
+
+  when /amd64|x86_64/
+    "x86_64"
+
+  when /ppc64|powerpc64/
+    "powerpc64"
+
+  when /ppc|powerpc/
+    "powerpc"
+
+  when /^arm/
+    "arm"
+
+  else
+    RbConfig::CONFIG['host_cpu']
+  end
+
+OS = case RbConfig::CONFIG['host_os'].downcase
+  when /linux/
+    "linux"
+  when /darwin/
+    "darwin"
+  when /freebsd/
+    "freebsd"
+  when /openbsd/
+    "openbsd"
+  when /sunos|solaris/
+    "solaris"
+  when /mswin|mingw/
+    "win32"
+  else
+    RbConfig::CONFIG['host_os'].downcase
+  end
+
+def compile_library(path, lib)
+  dir = File.expand_path(path, File.dirname(__FILE__))
+  lib = "#{dir}/#{lib}"
+  if !File.exist?(lib)
+    output = nil
+    FileUtils.cd(dir) do
+      output = system(*%{#{system('which gmake >/dev/null') && 'gmake' || 'make'} CPU=#{CPU} OS=#{OS} }.tap{|x| puts x.inspect})
+    end
+
+    if $?.exitstatus != 0
+      puts "ERROR:\n#{output}"
+      raise "Unable to compile \"#{lib}\""
+    end
+  end
+
+  lib
+end
+
+module TestLibrary
+  PATH = compile_library(".", "libtest.#{RbConfig::CONFIG['DLEXT']}")
+end

--- a/spec/ffi/platform_spec.rb
+++ b/spec/ffi/platform_spec.rb
@@ -6,7 +6,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
 
 describe "FFI::Platform::LIBSUFFIX" do
-  case OS
+  case TestLibrary::OS
   when "linux"
     it "returns 'so'" do
       expect(FFI::Platform::LIBSUFFIX).to eq('so')
@@ -23,7 +23,7 @@ describe "FFI::Platform::LIBSUFFIX" do
 end
 
 describe "FFI::Platform::IS_WINDOWS" do
-  case OS
+  case TestLibrary::OS
   when "linux"
     it "returns false" do
       expect(FFI::Platform::IS_WINDOWS).to be false
@@ -41,12 +41,12 @@ end
 
 describe "FFI::Platform::ARCH" do
   it "returns the architecture type" do
-    expect(FFI::Platform::ARCH).to eq(CPU)
+    expect(FFI::Platform::ARCH).to eq(TestLibrary::CPU)
   end
 end
 
 describe "FFI::Platform::OS" do
-  case OS
+  case TestLibrary::OS
   when "linux"
     it "returns 'linux' as a string" do
       expect(FFI::Platform::OS).to eq('linux')
@@ -63,7 +63,7 @@ describe "FFI::Platform::OS" do
 end
 
 describe "FFI::Platform.windows?" do
-  case OS
+  case TestLibrary::OS
   when "linux"
     it "returns false" do
       expect(FFI::Platform.windows?).to be false
@@ -80,7 +80,7 @@ describe "FFI::Platform.windows?" do
 end
 
 describe "FFI::Platform.mac?" do
-  case OS
+  case TestLibrary::OS
   when "linux"
     it "returns false" do
       expect(FFI::Platform.mac?).to be false
@@ -97,7 +97,7 @@ describe "FFI::Platform.mac?" do
 end
 
 describe "FFI::Platform.unix?" do
-  case OS
+  case TestLibrary::OS
   when "linux"
     it "returns true" do
       expect(FFI::Platform.unix?).to be true

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -5,78 +5,15 @@
 
 require 'rbconfig'
 require 'fileutils'
-require 'ffi'
 
 RSpec.configure do |c|
   c.filter_run_excluding :broken => true
 end
 
-CPU = case RbConfig::CONFIG['host_cpu'].downcase
-  when /i[3456]86/
-    # Darwin always reports i686, even when running in 64bit mode
-    if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
-      "x86_64"
-    else
-      "i386"
-    end
-
-  when /amd64|x86_64/
-    "x86_64"
-
-  when /ppc64|powerpc64/
-    "powerpc64"
-
-  when /ppc|powerpc/
-    "powerpc"
-
-  when /^arm/
-    "arm"
-
-  else
-    RbConfig::CONFIG['host_cpu']
-  end
-
-OS = case RbConfig::CONFIG['host_os'].downcase
-  when /linux/
-    "linux"
-  when /darwin/
-    "darwin"
-  when /freebsd/
-    "freebsd"
-  when /openbsd/
-    "openbsd"
-  when /sunos|solaris/
-    "solaris"
-  when /mswin|mingw/
-    "win32"
-  else
-    RbConfig::CONFIG['host_os'].downcase
-  end
-
-def compile_library(path, lib)
-
-  dir = File.expand_path(path, File.dirname(__FILE__))
-  lib = "#{dir}/#{lib}"
-  if !File.exist?(lib)
-    output = nil
-    FileUtils.cd(dir) do
-      output = system(*%{#{system('which gmake >/dev/null') && 'gmake' || 'make'} CPU=#{CPU} OS=#{OS} }.tap{|x| puts x.inspect})
-    end
-
-    if $?.exitstatus != 0
-      puts "ERROR:\n#{output}"
-      raise "Unable to compile \"#{lib}\""
-    end
-  end
-
-  lib
-end
-
-require "ffi"
+require_relative 'fixtures/compile'
+require 'ffi'
 
 module TestLibrary
-  PATH = compile_library("fixtures", "libtest.#{FFI::Platform::LIBSUFFIX}")
-
   def self.force_gc
     if RUBY_PLATFORM =~ /java/
       java.lang.System.gc
@@ -87,6 +24,7 @@ module TestLibrary
     end
   end
 end
+
 module LibTest
   extend FFI::Library
   ffi_lib TestLibrary::PATH

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -3,15 +3,11 @@
 # For licensing, see LICENSE.SPECS
 #
 
-require 'rbconfig'
-require 'fileutils'
+require_relative 'fixtures/compile'
 
 RSpec.configure do |c|
   c.filter_run_excluding :broken => true
 end
-
-require_relative 'fixtures/compile'
-require 'ffi'
 
 module TestLibrary
   def self.force_gc


### PR DESCRIPTION
Following the discussion in https://github.com/ffi/ffi/pull/676.
Now all benchmarks run fine, and importantly use the FFI built in the repo (instead of the installed gem).

This can run all benchmarks in a short time to verify they don't error out:
```
for f in bench/bench_*.rb; do echo $f; ITER=10 ruby $f; done
```

A good next step would be to convert benchmarks to use `benchmark-ips` since currently the number of iterations is arbitrary and often not so well calibrated. I'd rather let FFI maintainers do that though :smiley: 

cc @larskanis @tduehr 