### PR TITLE
Fix FFI::Pointer#read_string(0) to return a binary String

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -49,7 +49,7 @@ module FFI
     # equivalent string if +len+ is not +nil+.
     def read_string(len=nil)
       if len
-        return '' if len == 0
+        return ''.b if len == 0
         get_bytes(0, len)
       else
         get_string(0)

--- a/spec/ffi/rbx/memory_pointer_spec.rb
+++ b/spec/ffi/rbx/memory_pointer_spec.rb
@@ -37,6 +37,7 @@ describe "MemoryPointer" do
 
   it "reads back an empty string" do
     expect(FFI::Pointer::NULL.read_string(0)).to eq('')
+    expect(FFI::Pointer::NULL.read_string(0).encoding).to eq(Encoding::BINARY)
   end
   
   it "makes a pointer for a certain number of bytes" do


### PR DESCRIPTION
* Like other pointer string methods and usages.
* Fixes #691.
* String#b is available since Ruby 2.0.