### PR TITLE
Add specs for missing cases

### DIFF
--- a/spec/ffi/buffer_spec.rb
+++ b/spec/ffi/buffer_spec.rb
@@ -138,6 +138,14 @@ describe "Buffer#put_ulong_long" do
 end
 
 describe "Reading/Writing binary strings" do
+  it "Buffer#write_bytes and read_bytes" do
+    str = "hello\0world"
+    buf = FFI::Buffer.new 11
+    buf.write_bytes(str)
+    s2 = buf.read_bytes(11)
+    expect(s2).to eq(str)
+  end
+
   it "Buffer#put_bytes" do
     str = "hello\0world"
     buf = FFI::Buffer.new 1024

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -500,28 +500,32 @@ describe "Callback with " do
     expect(v).to eq(-1)
   end
 
+  def testCallbackU8rV(value)
+    v1 = 0xdeadbeef
+    LibTest.testCallbackU8rV(value) { |i| v1 = i }
+    expect(v1).to eq(value)
+
+    # Using a FFI::Function (v2) should be consistent with the direct callback (v1)
+    v2 = 0xdeadbeef
+    fun = FFI::Function.new(:void, [:uchar]) { |i| v2 = i }
+    LibTest.testCallbackU8rV(fun, value)
+    expect(v2).to eq(value)
+  end
+
   it ":uchar (0) argument" do
-    v = 0xdeadbeef
-    LibTest.testCallbackU8rV(0) { |i| v = i }
-    expect(v).to eq(0)
+    testCallbackU8rV(0)
   end
 
   it ":uchar (127) argument" do
-    v = 0xdeadbeef
-    LibTest.testCallbackU8rV(127) { |i| v = i }
-    expect(v).to eq(127)
+    testCallbackU8rV(127)
   end
 
   it ":uchar (128) argument" do
-    v = 0xdeadbeef
-    LibTest.testCallbackU8rV(128) { |i| v = i }
-    expect(v).to eq(128)
+    testCallbackU8rV(128)
   end
 
   it ":uchar (255) argument" do
-    v = 0xdeadbeef
-    LibTest.testCallbackU8rV(255) { |i| v = i }
-    expect(v).to eq(255)
+    testCallbackU8rV(255)
   end
 
   it ":short (0) argument" do

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -75,6 +75,7 @@ describe "Callback" do
     attach_function :testCallbackVrS64, :testClosureVrLL, [ :cbVrS64 ], :long_long
     attach_function :testCallbackVrU64, :testClosureVrLL, [ :cbVrU64 ], :ulong_long
     attach_function :testCallbackVrP, :testClosureVrP, [ :cbVrP ], :pointer
+    attach_function :testCallbackReturningFunction, :testClosureVrP, [ :cbVrP ], :cbVrP
     attach_function :testCallbackVrY, :testClosureVrP, [ :cbVrY ], S8F32S32.ptr
     attach_function :testCallbackVrT, :testClosureVrT, [ :cbVrT ], S8F32S32.by_value
     attach_function :testCallbackTrV, :testClosureTrV, [ :cbTrV, S8F32S32.ptr ], :void
@@ -264,6 +265,12 @@ describe "Callback" do
   it "returning :pointer (MemoryPointer)" do
     p = FFI::MemoryPointer.new :long
     expect(LibTest.testCallbackVrP { p }).to eq(p)
+  end
+
+  it "returning a callback function" do
+    ret = LibTest.testCallbackReturningFunction { FFI::Pointer.new(42) }
+    expect(ret).to be_kind_of(FFI::Function)
+    expect(ret.address).to eq(42)
   end
 
   it "returning struct by value" do

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -11,6 +11,7 @@ describe "String tests" do
     ffi_lib TestLibrary::PATH
     attach_function :ptr_ret_pointer, [ :pointer, :int], :string
     attach_function :string_equals, [ :string, :string ], :int
+    attach_function :pointer_string_equals, :string_equals, [ :pointer, :string ], :int
     attach_function :string_dummy, [ :string ], :void
     attach_function :string_null, [ ], :string
   end
@@ -30,6 +31,12 @@ describe "String tests" do
     str = StrLibTest.ptr_ret_pointer(mp, 0)
     expect(str).to eq("test")
     expect(str).to be_tainted
+  end
+
+  it "A String can be passed to a :pointer argument" do
+    str = "string buffer"
+    expect(StrLibTest.pointer_string_equals(str, str)).to eq(1)
+    expect(StrLibTest.pointer_string_equals(str + "a", str)).to eq(0)
   end
 
   it "Poison null byte raises error" do


### PR DESCRIPTION
Along with my mostly pure-Ruby implementation for TruffleRuby (#660), I discovered a few incompatibilities in TruffleRuby which were not covered by existing specs.

So in this PR, I add specs for previously untested code.
cc @larskanis