### PR TITLE
Complete gemspec metadata

### DIFF
--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -9,10 +9,12 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby FFI'
   s.description = 'Ruby FFI library'
   if s.respond_to?(:metadata)
-    s.metadata['changelog_uri'] = 'https://github.com/ffi/ffi/blob/master/CHANGELOG.md'
-    s.metadata['wiki_uri'] = 'https://github.com/ffi/ffi/wiki'
     s.metadata['bug_tracker_uri'] = 'https://github.com/ffi/ffi/issues'
-    s.metadata['source_code_uri'] = 'https://github.com/ffi/ffi/'    
+    s.metadata['changelog_uri'] = 'https://github.com/ffi/ffi/blob/master/CHANGELOG.md'
+    s.metadata['documentation_uri'] = 'https://github.com/ffi/ffi/wiki'
+    s.metadata['wiki_uri'] = 'https://github.com/ffi/ffi/wiki'
+    s.metadata['source_code_uri'] = 'https://github.com/ffi/ffi/'
+    s.metadata['mailing_list_uri'] = 'http://groups.google.com/group/ruby-ffi'
   end
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f =~ /^(bench|gen|libtest|nbproject|spec)/


### PR DESCRIPTION
In order not to lose any of the links at release, when RubyGems writes them in, again.

