### PR TITLE
Remove taint support

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -417,7 +417,7 @@ memory_get_string(int argc, VALUE* argv, VALUE self)
     checkBounds(ptr, off, len);
 
     end = memchr(ptr->address + off, 0, len);
-    return rb_tainted_str_new((char *) ptr->address + off,
+    return rb_str_new((char *) ptr->address + off,
             (end != NULL ? end - ptr->address - off : len));
 }
 
@@ -453,7 +453,7 @@ memory_get_array_of_string(int argc, VALUE* argv, VALUE self)
         
         for (i = 0; i < count; ++i) {
             const char* strptr = *((const char**) (ptr->address + off) + i);
-            rb_ary_push(retVal, (strptr == NULL ? Qnil : rb_tainted_str_new2(strptr)));
+            rb_ary_push(retVal, (strptr == NULL ? Qnil : rb_str_new2(strptr)));
         }
 
     } else {
@@ -463,7 +463,7 @@ memory_get_array_of_string(int argc, VALUE* argv, VALUE self)
             if (strptr == NULL) {
                 break;
             }
-            rb_ary_push(retVal, rb_tainted_str_new2(strptr));
+            rb_ary_push(retVal, rb_str_new2(strptr));
         }
     }
 
@@ -542,7 +542,7 @@ memory_get_bytes(VALUE self, VALUE offset, VALUE length)
     checkRead(ptr);
     checkBounds(ptr, off, len);
     
-    return rb_tainted_str_new((char *) ptr->address + off, len);
+    return rb_str_new((char *) ptr->address + off, len);
 }
 
 /*
@@ -583,10 +583,6 @@ memory_put_bytes(int argc, VALUE* argv, VALUE self)
     checkWrite(ptr);
     checkBounds(ptr, off, len);
 
-    if (rb_safe_level() >= 1 && OBJ_TAINTED(str)) {
-        rb_raise(rb_eSecurityError, "Writing unsafe string to memory");
-        return Qnil;
-    }
     memcpy(ptr->address + off, RSTRING_PTR(str) + idx, len);
 
     return self;
@@ -718,7 +714,7 @@ memory_op_get_strptr(AbstractMemory* ptr, long offset)
         memcpy(&tmp, ptr->address + offset, sizeof(tmp));
     }
 
-    return tmp != NULL ? rb_tainted_str_new2(tmp) : Qnil;
+    return tmp != NULL ? rb_str_new2(tmp) : Qnil;
 }
 
 static void

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -298,10 +298,6 @@ rbffi_SetupCallParams(int argc, VALUE* argv, int paramCount, Type** paramTypes,
                     param->ptr = NULL;
 
                 } else {
-                    if (rb_safe_level() >= 1 && OBJ_TAINTED(argv[argidx])) {
-                        rb_raise(rb_eSecurityError, "Unsafe string parameter");
-                    }
-
                     param->ptr = StringValueCStr(argv[argidx]);
                 }
 

--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -164,7 +164,7 @@ library_dlerror(VALUE self)
 {
     char errmsg[1024];
     dl_error(errmsg, sizeof(errmsg));
-    return rb_tainted_str_new2(errmsg);
+    return rb_str_new2(errmsg);
 }
 
 static void

--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -724,7 +724,7 @@ invoke_callback(VALUE data)
 	      param = rbffi_longdouble_new(*(long double *) parameters[i]);
                 break;
             case NATIVE_STRING:
-                param = (*(void **) parameters[i] != NULL) ? rb_tainted_str_new2(*(char **) parameters[i]) : Qnil;
+                param = (*(void **) parameters[i] != NULL) ? rb_str_new2(*(char **) parameters[i]) : Qnil;
                 break;
             case NATIVE_POINTER:
                 param = rbffi_Pointer_NewInstance(*(void **) parameters[i]);

--- a/ext/ffi_c/Types.c
+++ b/ext/ffi_c/Types.c
@@ -80,7 +80,7 @@ rbffi_NativeValue_ToRuby(Type* type, VALUE rbType, const void* ptr)
 	  return rbffi_longdouble_new(*(long double *) ptr);
 
         case NATIVE_STRING:
-            return (*(void **) ptr != NULL) ? rb_tainted_str_new2(*(char **) ptr) : Qnil;
+            return (*(void **) ptr != NULL) ? rb_str_new2(*(char **) ptr) : Qnil;
         case NATIVE_POINTER:
             return rbffi_Pointer_NewInstance(*(void **) ptr);
         case NATIVE_BOOL:

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -16,23 +16,6 @@ describe "String tests" do
     attach_function :string_null, [ ], :string
   end
 
-  it "MemoryPointer#get_string returns a tainted string" do
-    mp = FFI::MemoryPointer.new 1024
-    mp.put_string(0, "test\0")
-    str = mp.get_string(0)
-    expect(str.tainted?).to be true
-  end
-
-  it "String returned by a method is tainted" do
-    mp = FFI::MemoryPointer.new :pointer
-    sp = FFI::MemoryPointer.new 1024
-    sp.put_string(0, "test")
-    mp.put_pointer(0, sp)
-    str = StrLibTest.ptr_ret_pointer(mp, 0)
-    expect(str).to eq("test")
-    expect(str).to be_tainted
-  end
-
   it "A String can be passed to a :pointer argument" do
     str = "string buffer"
     expect(StrLibTest.pointer_string_equals(str, str)).to eq(1)
@@ -44,15 +27,6 @@ describe "String tests" do
     expect { StrLibTest.string_equals(s, s) }.to raise_error(ArgumentError)
   end
 
-  it "Tainted String parameter should throw a SecurityError" do
-    $SAFE = 1
-    str = "test"
-    str.taint
-    begin
-      expect(LibTest.string_equals(str, str)).to be false
-    rescue SecurityError
-    end
-  end if false
   it "casts nil as NULL pointer" do
     expect(StrLibTest.string_dummy(nil)).to be_nil
   end


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
https://bugs.ruby-lang.org/issues/16131

The APIs related to taint cause deprecation warning message and the lack of taint support should not cause a problem in previous Ruby versions.
So I removed that. But if need to taint support that to old versions of Ruby, I will update PR.