### PR TITLE
fix cast between incompatible function types

### DIFF
--- a/spec/ffi/fixtures/ClosureTest.c
+++ b/spec/ffi/fixtures/ClosureTest.c
@@ -78,7 +78,11 @@ struct ThreadVrV {
     int count;
 };
 
-static void *
+#ifndef _WIN32
+  static void *
+#else
+  static void
+#endif
 threadVrV(void *arg)
 {
     struct ThreadVrV* t = (struct ThreadVrV *) arg;
@@ -88,7 +92,11 @@ threadVrV(void *arg)
         (*t->closure)();
     }
     
-    return NULL;
+    #ifndef _WIN32
+      return NULL;
+    #else
+      return;
+    #endif
 }
 
 void testThreadedClosureVrV(void (*closure)(void), int n)
@@ -99,7 +107,7 @@ void testThreadedClosureVrV(void (*closure)(void), int n)
     pthread_create(&t, NULL, threadVrV, &arg);
     pthread_join(t, NULL);
 #else
-    HANDLE hThread = (HANDLE) _beginthread((void (*)(void *))threadVrV, 0, &arg);
+    HANDLE hThread = (HANDLE) _beginthread(threadVrV, 0, &arg);
     WaitForSingleObject(hThread, INFINITE);	
 #endif
 }


### PR DESCRIPTION
I have a warning on Windows
```
ClosureTest.c: In function 'testThreadedClosureVrV':
ClosureTest.c:102:44: warning: cast between incompatible function types from 'void * (*)(void *)' to 'void (*)(void *)' [-Wcast-function-type]
  102 |     HANDLE hThread = (HANDLE) _beginthread((void (*)(void *))threadVrV, 0, &arg);
```
gcc version 9.2.0

there's probably a better way how to fix it.