### PR TITLE
replace ffi_prep_closure with ffi_prep_closure_loc

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -864,9 +864,9 @@ callback_prep(void* ctx, void* code, Closure* closure, char* errmsg, size_t errm
     FunctionType* fnInfo = (FunctionType *) ctx;
     ffi_status ffiStatus;
 
-    ffiStatus = ffi_prep_closure(code, &fnInfo->ffi_cif, callback_invoke, closure);
+    ffiStatus = ffi_prep_closure_loc(code, &fnInfo->ffi_cif, callback_invoke, closure, code);
     if (ffiStatus != FFI_OK) {
-        snprintf(errmsg, errmsgsize, "ffi_prep_closure failed.  status=%#x", ffiStatus);
+        snprintf(errmsg, errmsgsize, "ffi_prep_closure_loc failed.  status=%#x", ffiStatus);
         return false;
     }
 

--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -144,10 +144,10 @@ prep_trampoline(void* ctx, void* code, Closure* closure, char* errmsg, size_t er
 #if defined(USE_RAW)
     ffiStatus = ffi_prep_raw_closure(code, &mh_cif, attached_method_invoke, closure);
 #else
-    ffiStatus = ffi_prep_closure(code, &mh_cif, attached_method_invoke, closure);
+    ffiStatus = ffi_prep_closure_loc(code, &mh_cif, attached_method_invoke, closure, code);
 #endif
     if (ffiStatus != FFI_OK) {
-        snprintf(errmsg, errmsgsize, "ffi_prep_closure failed.  status=%#x", ffiStatus);
+        snprintf(errmsg, errmsgsize, "ffi_prep_closure_loc failed.  status=%#x", ffiStatus);
         return false;
     }
 


### PR DESCRIPTION
```
../../../../ext/ffi_c/Function.c: In function 'callback_prep':
../../../../ext/ffi_c/Function.c:867:5: warning: 'ffi_prep_closure' is deprecated: use ffi_prep_closure_loc instead [-Wdeprecated-declarations]
```