### PR TITLE
Load JRuby ext under JRuby

### DIFF
--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -8,6 +8,10 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
 
   require 'ffi/ffi'
 
+elsif RUBY_ENGINE == 'jruby'
+  JRuby::Util.load_ext("org.jruby.ext.ffi.FFIService")
+  require 'ffi/ffi'
+
 elsif defined?(RUBY_ENGINE)
   # Remove the ffi gem dir from the load path, then reload the internal ffi implementation
   $LOAD_PATH.delete(File.dirname(__FILE__))


### PR DESCRIPTION
JRuby's FFI is almost aligned with the gem via jruby/jruby#5948. This change will allow us to use ffi.rb unmodified.