### PR TITLE
Make string return value from callback available

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -843,10 +843,11 @@ invoke_callback(VALUE data)
         case NATIVE_STRING:
             if (TYPE(rbReturnValue) == T_DATA) {
                 *((void **) retval) = ((AbstractMemory *) DATA_PTR(rbReturnValue))->address;
-            } else if (TYPE(rbReturnValue) == T_STRING) {
-                VALUE obj = rbffi_MemoryPointer_ForString(rbReturnValue);
-
-                *((void **) retval) = ((AbstractMemory *) DATA_PTR(obj))->address;
+//            This causes the block to get run twice
+//            } else if (TYPE(rbReturnValue) == T_STRING) {
+//                VALUE obj = rbffi_MemoryPointer_ForString(rbReturnValue);
+//
+//                *((void **) retval) = ((AbstractMemory *) DATA_PTR(obj))->address;
             } else {
                 *((void **) retval) = NULL;
             }

--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -844,10 +844,7 @@ invoke_callback(VALUE data)
             if (TYPE(rbReturnValue) == T_DATA) {
                 *((void **) retval) = ((AbstractMemory *) DATA_PTR(rbReturnValue))->address;
             } else if (TYPE(rbReturnValue) == T_STRING) {
-                VALUE s = StringValue(rbReturnValue);
-                VALUE args[] = { INT2FIX(1), LONG2NUM(RSTRING_LEN(s) + 1), Qfalse };
-                VALUE obj = rb_class_new_instance(3, args, rbffi_MemoryPointerClass);
-                rb_funcall(obj, rb_intern("put_string"), 2, INT2FIX(0), s);
+                VALUE obj = rbffi_MemoryPointer_ForString(rbReturnValue);
 
                 *((void **) retval) = ((AbstractMemory *) DATA_PTR(obj))->address;
             } else {

--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -839,6 +839,10 @@ invoke_callback(VALUE data)
             }
             break;
 
+        case NATIVE_STRING:
+            *((void **) retval) = ((AbstractMemory *) DATA_PTR(rbReturnValue))->address;
+            break;
+
         default:
             *((ffi_arg *) retval) = 0;
             break;

--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -167,6 +167,12 @@ memptr_s_from_string(VALUE klass, VALUE to_str)
     return obj;
 }
 
+VALUE
+rbffi_MemoryPointer_ForString(VALUE to_str)
+{
+    return memptr_s_from_string(rbffi_MemoryPointerClass, to_str);
+}
+
 void
 rbffi_MemoryPointer_Init(VALUE moduleFFI)
 {

--- a/ext/ffi_c/MemoryPointer.h
+++ b/ext/ffi_c/MemoryPointer.h
@@ -45,6 +45,7 @@ extern "C" {
     extern void rbffi_MemoryPointer_Init(VALUE moduleFFI);
     extern VALUE rbffi_MemoryPointerClass;
     extern VALUE rbffi_MemoryPointer_NewInstance(long size, long count, bool clear);
+    extern VALUE rbffi_MemoryPointer_ForString(VALUE to_str);
 #ifdef	__cplusplus
 }
 #endif

--- a/spec/ffi/fixtures/FunctionTest.c
+++ b/spec/ffi/fixtures/FunctionTest.c
@@ -129,6 +129,11 @@ void testAsyncCallback(void (*fn)(int), int value)
 #endif
 }
 
+char *testCallback(char * (*fn)(char *), char *value)
+{
+    return fn(value);
+}
+
 #if defined(_WIN32) && !defined(_WIN64)
 struct StructUCDP {
   unsigned char a1;

--- a/spec/ffi/string_callback_spec.rb
+++ b/spec/ffi/string_callback_spec.rb
@@ -1,0 +1,25 @@
+#
+# This file is part of ruby-ffi.
+# For licensing, see LICENSE.SPECS
+#
+
+require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
+
+describe "callback with return value" do
+  module LibTest
+    extend FFI::Library
+    ffi_lib TestLibrary::PATH
+
+    callback :greeter, [:string], :string
+
+    @blocking = true
+    attach_function :testCallback, [ :greeter, :string ], :string
+  end
+
+  it "accepts memory pointer with string" do
+    result = LibTest.testCallback("jack") do |name|
+      FFI::MemoryPointer.from_string("hello #{name}")
+    end
+    expect(result).to eq("hello jack")
+  end
+end


### PR DESCRIPTION
## Background
When a `callback` is defined, the return value isn't made available to the underlying C code if the return value is a `string` memory pointer; instead, it would return `null` to the caller.

## Disclaimer
Tested with two return values:
- `FFI::MemoryPointer.from_string()`
- Regular `string` value (does not work yet)

## Reference
- [SO Question](https://stackoverflow.com/questions/60689128/ruby-ffi-callback-return-values)

## Tested with
### Ruby code
```ruby
require 'ffi'

class Foo
  extend FFI::Library
  ffi_lib File.expand_path('fun.o')

  callback :incoming_rpc, [:string], :string
  attach_function :do_some_work, [:incoming_rpc, :string], :string

  def initialize
    output = do_some_work("Ruby init...") do |name|
      FFI::MemoryPointer.from_string("hello #{name}")
    end
    puts "Output: #{output.inspect}"
  end
end

Foo.new
```
### C code
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

typedef const char *callbkfn(char *);

extern char* do_some_work(callbkfn fn, char *name);

char* do_some_work(callbkfn fn, char* userdata) {
  printf("do_some_work param: %s\n", userdata);
  printf("callback output: %s\n", fn(strdup("Hello from C")));
  return strdup("Returned from C");
}
```