### PR TITLE
Add ruby source files to the java gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,16 +65,9 @@ task :default => :spec
 
 namespace 'java' do
 
-  java_gem_spec = Gem::Specification.new do |s|
-    s.name = gem_spec.name
-    s.version = gem_spec.version
-    s.author = gem_spec.author
-    s.email = gem_spec.email
-    s.homepage = gem_spec.homepage
-    s.summary = gem_spec.summary
-    s.description = gem_spec.description
-    s.files = %w(LICENSE COPYING README.md CHANGELOG.md Rakefile)
-    s.license = gem_spec.license
+  java_gem_spec = gem_spec.dup.tap do |s|
+    s.files.reject! { |f| File.fnmatch?("ext/*", f) }
+    s.extensions = []
     s.platform = 'java'
   end
 

--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -8,7 +8,7 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
 
   require 'ffi/ffi'
 
-elsif RUBY_ENGINE == 'jruby'
+elsif RUBY_ENGINE == 'jruby' && Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new("9.3.pre")
   JRuby::Util.load_ext("org.jruby.ext.ffi.FFIService")
   require 'ffi/ffi'
 


### PR DESCRIPTION
Related to https://github.com/ffi/ffi/pull/747 .

JRuby-9.3 is expected to be fully compatible to this gem's Ruby code. This allows to ship the Ruby library code per platform java gem and add it as a default gem to JRuby.