### PR TITLE
Remove redundant CI jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,6 @@
 install:
   - SET PATH=C:\Ruby%RUBYVER%\bin;%PATH%
   - SET RAKEOPT=-rdevkit
-  - ps: |
-      if ($env:RUBYVER -like "*head*") {
-        $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-$env:RUBYVER.exe", "$pwd/ruby-setup.exe")
-        cmd /c ruby-setup.exe /verysilent /dir=C:/Ruby$env:RUBYVER
-      }
   - ridk version
   - gem --version
   - gem install bundler --quiet --no-document
@@ -20,10 +15,6 @@ test_script:
   - bundle exec rake types_conf && git --no-pager diff
 environment:
   matrix:
-    - RUBYVER: "head-x64"
-      EXTCONFOPTS: "--disable-system-libffi"
-    - RUBYVER: 24
-      EXTCONFOPTS: "--disable-system-libffi"
     - RUBYVER: 25-x64
       EXTCONFOPTS: "--enable-system-libffi"
     - RUBYVER: 26

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,58 +1,19 @@
 dist: trusty
 group: beta
-language: ruby
+language: generic
 git:
   submodules: false
-
-script:
-  - bundle exec rake libffi
-  - bundle exec rake compile
-  - bundle exec rake test
-  - |
-      if [[ $(ruby -v) != *truffleruby* ]]; then
-        ITER=10 bundle exec rake bench:all
-      fi
-  - bundle exec rake types_conf && git --no-pager diff
-os:
-  - linux
-  - osx
-rvm:
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.5
-  - 2.7.0
-  - ruby-head
-  - truffleruby-head
-
-env:
-  - CC=gcc
-  - CC=clang
 matrix:
-  allow_failures:
-    - os: osx
-      rvm: ruby-head
-    - os: osx
-      rvm: 2.3.8
-    - os: linux
-      rvm: ruby-head
   include:
     - name: powerpc
-      language: generic
       before_install: |
         docker run --rm --privileged multiarch/qemu-user-static:register --reset &&
           docker build --rm -t ffi-powerpc -f spec/env/Dockerfile.powerpc .
       script: |
         docker run --rm -t -v `pwd`:/ffi ffi-powerpc
     - name: armhf
-      language: generic
       before_install: |
         docker run --rm --privileged multiarch/qemu-user-static:register --reset &&
           docker build --rm -t ffi-armhf -f spec/env/Dockerfile.armhf .
       script: |
         docker run --rm -t -v `pwd`:/ffi ffi-armhf
-  exclude:
-    - os: osx
-      rvm: truffleruby-head
-after_failure:
-  - "find build -name mkmf.log | xargs cat"


### PR DESCRIPTION
See https://github.com/ffi/ffi/issues/760#issuecomment-605897217

We should be able to move the remaining jobs to GitHub Actions as well, but might as well cleanup the redundant ones now.