### PR TITLE
Add SDK path on macOS

### DIFF
--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -8,7 +8,8 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     # We need pkg_config or ffi.h
     libffi_ok = pkg_config("libffi") ||
         have_header("ffi.h") ||
-        find_header("ffi.h", "/usr/local/include", "/usr/include/ffi")
+        find_header("ffi.h", "/usr/local/include", "/usr/include/ffi") ||
+        (find_header("ffi.h", `xcrun --sdk macosx --show-sdk-path`.strip + "/usr/include/ffi") rescue false)
 
     # Ensure we can link to ffi_call
     libffi_ok &&= have_library("ffi", "ffi_call", [ "ffi.h" ]) ||


### PR DESCRIPTION
macOS removed `/usr/include` in recent versions of macOS. This forces the usage of the internal libffi although macOS has a usable one itself.

Related to #757 . This is an alternative approach to #758 .