### PR TITLE
Implement callback returning type :string

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -793,6 +793,15 @@ invoke_callback(VALUE data)
         case NATIVE_FLOAT64:
             *((double *) retval) = NUM2DBL(rbReturnValue);
             break;
+
+        case NATIVE_STRING:
+            if (NIL_P(rbReturnValue)) {
+                *((void **) retval) = NULL;
+            } else {
+                *((void **) retval) = StringValueCStr(rbReturnValue);
+            }
+            break;
+
         case NATIVE_POINTER:
             if (TYPE(rbReturnValue) == T_DATA && rb_obj_is_kind_of(rbReturnValue, rbffi_PointerClass)) {
                 *((void **) retval) = ((AbstractMemory *) DATA_PTR(rbReturnValue))->address;

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -51,6 +51,7 @@ module CallbackSpecs
       callback :cbVrUL, [ ], :ulong
       callback :cbVrS64, [ ], :long_long
       callback :cbVrU64, [ ], :ulong_long
+      callback :cbVrA, [], :string
       callback :cbVrP, [], :pointer
       callback :cbVrZ, [], :bool
       callback :cbCrV, [ :char ], :void
@@ -75,6 +76,7 @@ module CallbackSpecs
       attach_function :testCallbackVrUL, :testClosureVrL, [ :cbVrUL ], :ulong
       attach_function :testCallbackVrS64, :testClosureVrLL, [ :cbVrS64 ], :long_long
       attach_function :testCallbackVrU64, :testClosureVrLL, [ :cbVrU64 ], :ulong_long
+      attach_function :testCallbackVrA, :testClosureVrP, [ :cbVrA ], :string
       attach_function :testCallbackVrP, :testClosureVrP, [ :cbVrP ], :pointer
       attach_function :testCallbackReturningFunction, :testClosureVrP, [ :cbVrP ], :cbVrP
       attach_function :testCallbackVrY, :testClosureVrP, [ :cbVrY ], S8F32S32.ptr
@@ -259,6 +261,15 @@ module CallbackSpecs
 
     it "returning bool" do
       expect(LibTest.testCallbackVrZ { true }).to be true
+    end
+
+    it "returning :string (nil)" do
+      expect(LibTest.testCallbackVrA { nil }).to be_nil
+    end
+
+    it "returning :string" do
+      str = "String ä"
+      expect(LibTest.testCallbackVrA { str }).to eq(str.b)
     end
 
     it "returning :pointer (nil)" do


### PR DESCRIPTION
Callbacks returning a `:string` type were not supported so far. It was possible to define such a callback, but the value returned was `NULL` in any case. This implementation follows the semantics for passing `:string` parameters to functions as [implemented in `Call.c`](https://github.com/ffi/ffi/blob/31db4122f7ee9b67323b3e28c00b35e8d374a3cd/ext/ffi_c/Call.c#L296-L306). That means in particular usage of `StringValueCStr()`, so that no zero bytes are allowed in the string.

Special care has to be taken regarding lifetime of the returned text pointer. The C pointer to the string is only valid until the next GC triggering function is called, unless the String object is hold in Ruby outside of the callback block. Even when the object is stored outside of the Ruby block, the text pointer can move when GC.compact is called. So `:string` returning callbacks can safely be used only, when the referenced text is processed immediately by the calling C function.

Return type `:string` is already implemented in TruffleRuby, but [fails in JRuby](https://github.com/jruby/jruby/blob/4e8bb2666a7257f0f5986800f96bb88efdd6acbd/core/src/main/java/org/jruby/ext/ffi/jffi/NativeClosureProxy.java#L107) and raises a
```Ruby
TypeError: invalid callback return type: STRING
```

Resolves #751

- [ ] Update the Wiki accordingly

@eregon, @headius  What do you think about this addition? Should we add `:string` returning callbacks in JRuby or deny them on all implementations?
