### PR TITLE
Improve check to detect if a module has a #find_type method suitable for FFI

### DIFF
--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -244,7 +244,9 @@ module FFI
       def enclosing_module
         begin
           mod = self.name.split("::")[0..-2].inject(Object) { |obj, c| obj.const_get(c) }
-          (mod < FFI::Library || mod < FFI::Struct || mod.respond_to?(:find_type)) ? mod : nil
+          if mod.respond_to?(:find_type) && (mod.is_a?(FFI::Library) || mod < FFI::Struct)
+            mod
+          end
         rescue Exception
           nil
         end

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -588,6 +588,23 @@ describe FFI::Struct, ".layout" do
       instance[:number] = 0xA1
       expect(FFISpecs::LibTest.ptr_ret_int32_t(instance, 0)).to eq(0xA1)
     end
+
+    it "ignores a module which does not extend FFI::Library or subclass FFI::Struct" do
+      module FFISpecs::UnrelatedFindTypeTest
+        # MakeMakefile from 'mkmf' defines such a method
+        def self.find_type(*args)
+          raise "should not be called"
+        end
+
+        class TestStruct < FFI::Struct
+          layout :number, :int
+        end
+      end
+
+      instance = FFISpecs::UnrelatedFindTypeTest::TestStruct.new
+      instance[:number] = 123
+      expect(FFISpecs::LibTest.ptr_ret_int32_t(instance, 0)).to eq(123)
+    end
   end
 end
 


### PR DESCRIPTION
* Fixes https://github.com/ffi/ffi/issues/776