### PR TITLE
Stick to older rubygems-tasks, to avoid dependency to too old irb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ group :development do
   gem 'rake-compiler', '~> 1.0.3'
   gem 'rake-compiler-dock', '~> 1.0'
   gem 'rspec', '~> 3.0'
-  gem 'rubygems-tasks', '~> 0.2.4', :require => 'rubygems/tasks'
-  # irb is a dependency of rubygems-tasks 0.2.5. irb 1.1.1 is the last version to not depend on reline,
+  # irb is a dependency of rubygems-tasks 0.2.5.
+  # irb versions > 1.1.1 depend on reline,
   # which sometimes causes 'bundle install' to fail on Ruby <= 2.4: https://github.com/rubygems/rubygems/issues/3463
-  gem 'irb', '1.1.1'
+  gem 'rubygems-tasks', '>= 0.2', '< 0.2.5', :require => 'rubygems/tasks'
 end
 
 group :doc do


### PR DESCRIPTION
irb-1.1.1 fails on ruby-2.7 with:

```ruby
lars@l1056lx:~/comcard/ffi$  git:(master) 1M 2A irb
Traceback (most recent call last):
	7: from /home/lars/.rvm/gems/ruby-2.7.1/bin/ruby_executable_hooks:24:in `<main>'
	6: from /home/lars/.rvm/gems/ruby-2.7.1/bin/ruby_executable_hooks:24:in `eval'
	5: from /home/lars/.rvm/gems/ruby-2.7.1/bin/irb:23:in `<main>'
	4: from /home/lars/.rvm/gems/ruby-2.7.1/bin/irb:23:in `load'
	3: from /home/lars/.rvm/gems/ruby-2.7.1/gems/irb-1.1.1/exe/irb:9:in `<top (required)>'
	2: from /home/lars/.rvm/gems/ruby-2.7.1/gems/irb-1.1.1/exe/irb:9:in `require'
	1: from /home/lars/.rvm/gems/ruby-2.7.1/gems/irb-1.1.1/lib/irb.rb:12:in `<top (required)>'
/home/lars/.rvm/gems/ruby-2.7.1/gems/irb-1.1.1/lib/irb.rb:12:in `require': cannot load such file -- e2mmap (LoadError)
```