### PR TITLE
[WIP] Reject callback with :string return type

### DIFF
--- a/ext/ffi_c/FunctionInfo.c
+++ b/ext/ffi_c/FunctionInfo.c
@@ -172,14 +172,13 @@ fntype_initialize(int argc, VALUE* argv, VALUE self)
         VALUE typeName = rb_funcall2(rbReturnType, rb_intern("inspect"), 0, NULL);
         rb_raise(rb_eTypeError, "Invalid return type (%s)", RSTRING_PTR(typeName));
     }
-    
+
     if (rb_obj_is_kind_of(fnInfo->rbReturnType, rbffi_StructByValueClass)) {
         fnInfo->hasStruct = true;
     }
 
     Data_Get_Struct(fnInfo->rbReturnType, Type, fnInfo->returnType);
     fnInfo->ffiReturnType = fnInfo->returnType->ffiType;
-
 
 #if defined(X86_WIN32)
     rbConventionStr = (rbConvention != Qnil) ? rb_funcall2(rbConvention, rb_intern("to_s"), 0, NULL) : Qnil;

--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -394,7 +394,11 @@ module FFI
       options = Hash.new
       options[:convention] = ffi_convention
       options[:enums] = @ffi_enums if defined?(@ffi_enums)
-      cb = FFI::CallbackInfo.new(find_type(ret), native_params, options)
+      ret_type = find_type(ret)
+      if ret_type == FFI::Type::Builtin::STRING
+        raise TypeError, ":string is not allowed as return type of callbacks"
+      end
+      cb = FFI::CallbackInfo.new(ret_type, native_params, options)
 
       # Add to the symbol -> type map (unless there was no name)
       unless name.nil?

--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -228,7 +228,11 @@ module FFI
 
       def callback(params, ret)
         mod = enclosing_module
-        FFI::CallbackInfo.new(find_type(ret, mod), params.map { |e| find_type(e, mod) })
+        ret_type = find_type(ret, mod)
+        if ret_type == FFI::Type::Builtin::STRING
+          raise TypeError, ":string is not allowed as return type of callbacks"
+        end
+        FFI::CallbackInfo.new(ret_type, params.map { |e| find_type(e, mod) })
       end
 
       def packed(packed = 1)

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -309,6 +309,15 @@ module CallbackSpecs
       expect(s2[:f32]).to be_within(0.0000001).of 1.234567
     end
 
+    it "returning :string is rejected as typedef" do
+      expect {
+        Module.new do
+          extend FFI::Library
+          ffi_lib TestLibrary::PATH
+          callback :cbVrA, [], :string
+        end
+      }.to raise_error(TypeError)
+    end
 
     it "global variable" do
       proc = Proc.new { 0x1e }

--- a/spec/ffi/struct_callback_spec.rb
+++ b/spec/ffi/struct_callback_spec.rb
@@ -66,4 +66,12 @@ describe FFI::Struct, ' with inline callback functions' do
     expect(fn.respond_to?(:call)).to be true
     expect(fn.call(1, 2)).to eq(3)
   end
+
+  it "callback returning :string is rejected in struct" do
+    expect {
+      Class.new(FFI::Struct) do
+        layout :function1, callback([:int, :int], :string)
+      end
+    }.to raise_error(TypeError)
+  end
 end


### PR DESCRIPTION
Callbacks returning a :string type were not supported so far. It was possible to define such a callback, but the value returned was NULL in any case. This implementation rejects :string return type of callbacks.

The reason for the reject is the following: In contrast to :string parameters to called functions there is no well defined ownership of the memory of the string returned by callbacks. Instead an explicit FFI::MemoryPointer or similar should be used, which allows to track the validity of underlying memory instead of relying on some Ruby implementation details.

Fixes #751
Alternative to #770