### PR TITLE
Remove code required for ruby prior 2.3

### DIFF
--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -339,13 +339,7 @@ static void *
 call_blocking_function(void* data)
 {
     rbffi_blocking_call_t* b = (rbffi_blocking_call_t *) data;
-#ifndef HAVE_RUBY_THREAD_HAS_GVL_P
-    b->frame->has_gvl = false;
-#endif
     ffi_call(&b->cif, FFI_FN(b->function), b->retval, b->ffiValues);
-#ifndef HAVE_RUBY_THREAD_HAS_GVL_P
-    b->frame->has_gvl = true;
-#endif
 
     return NULL;
 }

--- a/ext/ffi_c/Thread.c
+++ b/ext/ffi_c/Thread.c
@@ -74,9 +74,6 @@ void
 rbffi_frame_push(rbffi_frame_t* frame)
 {
     memset(frame, 0, sizeof(*frame));
-#ifndef HAVE_RUBY_THREAD_HAS_GVL_P
-    frame->has_gvl = true;
-#endif
     frame->exc = Qnil;
 
 #ifdef _WIN32

--- a/ext/ffi_c/Thread.h
+++ b/ext/ffi_c/Thread.h
@@ -66,9 +66,6 @@ typedef struct rbffi_frame {
     struct thread_data* td;
 #endif
     struct rbffi_frame* prev;
-#ifndef HAVE_RUBY_THREAD_HAS_GVL_P
-    bool has_gvl;
-#endif
     VALUE exc;
 } rbffi_frame_t;
 

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -45,13 +45,6 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     abort "system libffi is not usable" unless system_libffi_usable?
   end
 
-  have_func('rb_thread_call_without_gvl') || abort("Ruby C-API function `rb_thread_call_without_gvl` is missing")
-  have_func('ruby_native_thread_p')
-  if RUBY_VERSION >= "2.3.0"
-    # On OSX and Linux ruby_thread_has_gvl_p() is detected but fails at runtime for ruby < 2.3.0
-    have_func('ruby_thread_has_gvl_p')
-  end
-
   if system_libffi
     have_func('ffi_prep_cif_var')
     $defs << "-DHAVE_RAW_API" if have_func("ffi_raw_call") && have_func("ffi_prep_raw_closure")

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -843,12 +843,10 @@ module CallbackInteropSpecs
     end
 
     # https://github.com/ffi/ffi/issues/527
-    if RUBY_VERSION.split('.').map(&:to_i).pack("C*") >= [2,3,0].pack("C*") || RUBY_PLATFORM =~ /java/
-      it "from fiddle to ffi" do
-        assert_callback_in_same_thread_called_once do |block|
-          func = FFI::Function.new(:void, [:pointer], &block)
-          LibTestFiddle.testClosureVrV(Fiddle::Pointer[func.to_i])
-        end
+    it "from fiddle to ffi" do
+      assert_callback_in_same_thread_called_once do |block|
+        func = FFI::Function.new(:void, [:pointer], &block)
+        LibTestFiddle.testClosureVrV(Fiddle::Pointer[func.to_i])
       end
     end
 
@@ -877,7 +875,7 @@ module CallbackInteropSpecs
     end
 
     # https://github.com/ffi/ffi/issues/527
-    if RUBY_ENGINE == 'ruby' && RUBY_VERSION.split('.').map(&:to_i).pack("C*") >= [2,3,0].pack("C*")
+    if RUBY_ENGINE == 'ruby'
       it "C outside ffi call stack does not deadlock [#527]" do
         skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
         path = File.join(File.dirname(__FILE__), "embed-test/embed-test.rb")

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -185,21 +185,18 @@ module StructSpecsStructTests
       expect(mp.get_int64(4)).to eq(0xfee1deadbeef)
     end
 
-    rb_maj, rb_min = RUBY_VERSION.split('.')
-    if rb_maj.to_i >= 1 && rb_min.to_i >= 9 || RUBY_PLATFORM =~ /java/
-      it "Struct#layout withs with a hash of :name => type" do
-        class HashLayout < FFI::Struct
-          layout :a => :int, :b => :long_long
-        end
-        ll_off = (FFI::TYPE_UINT64.alignment == 4 ? 4 : 8)
-        expect(HashLayout.size).to eq(ll_off + 8)
-        mp = FFI::MemoryPointer.new(HashLayout.size)
-        s = HashLayout.new mp
-        s[:a] = 0x12345678
-        expect(mp.get_int(0)).to eq(0x12345678)
-        s[:b] = 0xfee1deadbeef
-        expect(mp.get_int64(ll_off)).to eq(0xfee1deadbeef)
+    it "Struct#layout withs with a hash of :name => type" do
+      class HashLayout < FFI::Struct
+        layout :a => :int, :b => :long_long
       end
+      ll_off = (FFI::TYPE_UINT64.alignment == 4 ? 4 : 8)
+      expect(HashLayout.size).to eq(ll_off + 8)
+      mp = FFI::MemoryPointer.new(HashLayout.size)
+      s = HashLayout.new mp
+      s[:a] = 0x12345678
+      expect(mp.get_int(0)).to eq(0x12345678)
+      s[:b] = 0xfee1deadbeef
+      expect(mp.get_int64(ll_off)).to eq(0xfee1deadbeef)
     end
 
     it "subclass overrides initialize without calling super" do

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -33,7 +33,6 @@ describe "Function with variadic arguments" do
   end
 
   it 'can wrap a blocking function with varargs' do
-    pending("not supported in 1.8") if RUBY_VERSION =~ /^1\.8\..*/
     handle = LibTest.testBlockingOpen
     expect(handle).not_to be_null
     begin


### PR DESCRIPTION
Now that the gemspec requires ruby-2.3 or newer, compatibility code can be removed.