### PR TITLE
Implement MemoryPointer.from_string in Ruby instead of C

### DIFF
--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -150,23 +150,6 @@ memptr_release(Pointer* ptr)
     xfree(ptr);
 }
 
-/*
- * call-seq: from_string(s)
- * @param [String] s string
- * @return [MemoryPointer]
- * Create a {MemoryPointer} with +s+ inside.
- */
-static VALUE
-memptr_s_from_string(VALUE klass, VALUE to_str)
-{
-    VALUE s = StringValue(to_str);
-    VALUE args[] = { INT2FIX(1), LONG2NUM(RSTRING_LEN(s) + 1), Qfalse };
-    VALUE obj = rb_class_new_instance(3, args, klass);
-    rb_funcall(obj, rb_intern("put_string"), 2, INT2FIX(0), s);
-
-    return obj;
-}
-
 void
 rbffi_MemoryPointer_Init(VALUE moduleFFI)
 {
@@ -192,6 +175,4 @@ rbffi_MemoryPointer_Init(VALUE moduleFFI)
 
     rb_define_alloc_func(rbffi_MemoryPointerClass, memptr_allocate);
     rb_define_method(rbffi_MemoryPointerClass, "initialize", memptr_initialize, -1);
-    rb_define_singleton_method(rbffi_MemoryPointerClass, "from_string", memptr_s_from_string, 1);
 }
-

--- a/lib/ffi/memorypointer.rb
+++ b/lib/ffi/memorypointer.rb
@@ -1,1 +1,46 @@
-# This class is now implemented in C
+#
+# Copyright (C) 2020 Lars Kanis
+#
+# This file is part of ruby-ffi.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the Ruby FFI project nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+module FFI
+  class MemoryPointer
+
+    # @param [String] s string
+    # @return [MemoryPointer]
+    # Create a {MemoryPointer} with +s+ inside.
+    def self.from_string(s)
+      raise TypeError, "no implicit conversion of #{s.inspect} into String" unless s.respond_to?(:to_str)
+      s = s.to_str
+      m = new(1, s.bytesize + 1, false)
+      m.put_string(0, s)
+      m
+    end
+  end
+end


### PR DESCRIPTION
This is more readable and should be faster due to inline caching.