### PR TITLE
Revert to msvcrt.dll as LIBC on MINGW

### DIFF
--- a/bench/bench_time.rb
+++ b/bench/bench_time.rb
@@ -4,7 +4,7 @@ module BenchTime
   module Posix
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
-    if FFI::Platform.windows?
+    if RUBY_PLATFORM =~ /mswin/
       attach_function :time, :_time64, [ :buffer_out ], :uint64, ignore_error: true
     else
       attach_function :time, [ :buffer_out ], :ulong, ignore_error: true

--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -129,7 +129,11 @@ module FFI
     end
 
     LIBC = if IS_WINDOWS
-      "ucrtbase.dll"
+      if RbConfig::CONFIG['host_os'] =~ /mingw/i
+        RbConfig::CONFIG['RUBY_SO_NAME'].split('-')[-2] + '.dll'
+      else
+        "ucrtbase.dll"
+      end
     elsif IS_GNU
       GNU_LIBC
     elsif OS == 'cygwin'

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -64,6 +64,20 @@ describe "Library" do
     end
   end
 
+  if RbConfig::CONFIG['host_os'] =~ /mingw/
+    # See https://github.com/ffi/ffi/issues/788
+    it "libc functions shouldn't call an invalid parameter handler" do
+      mod = Module.new do
+        extend FFI::Library
+        ffi_lib 'c'
+        attach_function(:get_osfhandle, :_get_osfhandle, [:int], :intptr_t)
+      end
+
+      expect( mod.get_osfhandle(42) ).to eq(-1)
+    end
+  end
+
+
   describe "ffi_lib" do
     it "empty name list should raise error" do
       expect {


### PR DESCRIPTION
ffi-1.13.0 switched FFI::Library::LIBC from msvcrt.dll to ucrtbase.dll as part of #779 in commit c67468366e63bcf84512837384049fbba7e4748c .

As described in #788 ucrtbase.dll has behavioural changes which shouldn't be released as part of a minor version change of ffi. While the change makes sense for mswin, we revert it for mingw.

Fixes #788