### PR TITLE
Fix possible UTF-8 error in ffi_lib rescue block

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -115,7 +115,7 @@ module FFI
             rescue Exception => ex
               ldscript = false
               if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short|invalid file format)/
-                if File.read($1) =~ /(?:GROUP|INPUT) *\( *([^ \)]+)/
+                if File.binread($1) =~ /(?:GROUP|INPUT) *\( *([^ \)]+)/
                   libname = $1
                   ldscript = true
                 end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -88,6 +88,32 @@ describe "Library" do
       }.to raise_error(LoadError)
     end
 
+    it "interprets INPUT() in loader scripts", unless: FFI::Platform.windows? do
+      path = File.dirname(TestLibrary::PATH)
+      file = File.basename(TestLibrary::PATH)
+      script = File.join(path, "ldscript.so")
+      File.write script, "INPUT(#{file});\n"
+
+      m = Module.new do |m|
+        m.extend FFI::Library
+        ffi_lib script
+      end
+      expect(m.ffi_libraries.map(&:name)).to eq([file])
+    end
+
+    it "raises LoadError on garbage in library file" do
+      path = File.dirname(TestLibrary::PATH)
+      file = File.basename(TestLibrary::PATH)
+      garbage = File.join(path, "ldscript.so")
+      File.binwrite garbage, "\xDE\xAD\xBE\xEF"
+
+      expect {
+        Module.new do |m|
+          m.extend FFI::Library
+          ffi_lib garbage
+        end
+      }.to raise_error(LoadError)
+    end
   end
 
   unless RbConfig::CONFIG['target_os'] =~ /mswin|mingw/


### PR DESCRIPTION
When a library can not be loaded is is tried to be interpret as a loader script.
This failed when the failing library is a binary file and has no valid UTF-8 content.
In this case the original LoadError was hidden.
Open as a binary file fixes this.

Also add a spec for loader script interpretation.

Fixes #792