### PR TITLE
Add support for new thread scheduler of Ruby-3.0

### DIFF
--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -347,7 +347,15 @@ call_blocking_function(void* data)
 VALUE
 rbffi_do_blocking_call(VALUE data)
 {
-    rb_thread_call_without_gvl(call_blocking_function, (void*)data, (rb_unblock_function_t *) -1, NULL);
+#if defined(HAVE_RB_CURRENT_THREAD_SCHEDULER)
+    VALUE scheduler = rb_current_thread_scheduler();
+    if (scheduler != Qnil) {
+        rbffi_blocking_region(call_blocking_function, (void*)data, (rb_unblock_function_t *) -1, NULL);
+    } else
+#endif
+    {
+        rb_thread_call_without_gvl(call_blocking_function, (void*)data, (rb_unblock_function_t *) -1, NULL);
+    }
 
     return Qnil;
 }

--- a/ext/ffi_c/Thread.h
+++ b/ext/ffi_c/Thread.h
@@ -37,6 +37,7 @@
 # include "win32/stdint.h"
 #endif
 #include <ruby.h>
+#include <ruby/io.h>
 #include "extconf.h"
 
 #ifdef	__cplusplus
@@ -72,6 +73,8 @@ typedef struct rbffi_frame {
 rbffi_frame_t* rbffi_frame_current(void);
 void rbffi_frame_push(rbffi_frame_t* frame);
 void rbffi_frame_pop(rbffi_frame_t* frame);
+
+void *rbffi_blocking_region(void *(*func)(void *), void *data1, void (*ubf)(void *), void *data2);
 
 #ifdef	__cplusplus
 }

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -52,6 +52,8 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     $defs << "-DUSE_INTERNAL_LIBFFI"
   end
 
+  have_func('rb_current_thread_scheduler')
+
   $defs << "-DHAVE_EXTCONF_H" if $defs.empty? # needed so create_header works
 
   create_header


### PR DESCRIPTION
The feature is described in: https://bugs.ruby-lang.org/issues/16786

To avoid blocking the current ruby thread while calls to C, calls can be executed in a dedicated pthread. This happens when the current thread has a scheduler assigned by `Thread.current.scheduler=` and the function is marked as `blocking: true` .

A pipe is used to signal the end of a call and the scheduler is invoked in order to wait for readability of the pipe. This way the scheduler can yield to another fiber or do other work instead of blocking the thread until the C call finishes.

The current implementation does not yield any callbacks back to the calling thread. Instead all callbacks invoked in this way are handled as asynchronous callbacks. This means that each callback is executed in a dedicated ruby thread.

cc: @ioquatix
