### PR TITLE
Use aarch64 as FFI::Platform::ARCH on MacOS

### DIFF
--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -71,13 +71,12 @@ module FFI
       "powerpc"
     when /sparcv9|sparc64/
       "sparcv9"
+    when /arm64|aarch64/  # MacOS calls it "arm64", other operating systems "aarch64"
+      "aarch64"
+    when /^arm/
+      "arm"
     else
-      case RbConfig::CONFIG['host_cpu']
-      when /^arm/
-        "arm"
-      else
-        RbConfig::CONFIG['host_cpu']
-      end
+      RbConfig::CONFIG['host_cpu']
     end
 
     private


### PR DESCRIPTION
"arm64" is only used on MacOS - other platforms call it "aarch64". Since it's the same architectur unify it to "aarch64".

Related to #801 