### PR TITLE
Do NULL pointer check only when array length > 0

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -141,7 +141,7 @@ memory_put_array_of_##name(VALUE self, VALUE offset, VALUE ary) \
     long i; \
     Check_Type(ary, T_ARRAY); \
     count = RARRAY_LEN(ary); \
-    checkWrite(memory); \
+    if (likely(count > 0)) checkWrite(memory); \
     checkBounds(memory, off, count * sizeof(type)); \
     for (i = 0; i < count; i++) { \
         type tmp = (type) VAL(toNative(RARRAY_PTR(ary)[i]), swap); \
@@ -164,7 +164,7 @@ memory_get_array_of_##name(VALUE self, VALUE offset, VALUE length) \
     AbstractMemory* memory = MEMORY(self); \
     VALUE retVal = rb_ary_new2(count); \
     long i; \
-    checkRead(memory); \
+    if (likely(count > 0)) checkRead(memory); \
     checkBounds(memory, off, count * sizeof(type)); \
     for (i = 0; i < count; ++i) { \
         type tmp; \

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -143,6 +143,11 @@ describe "Pointer" do
     it 'returns true when compared with nil' do
       expect((FFI::Pointer::NULL == nil)).to be true
     end
+    it 'should not raise an error when attempting read/write zero length array' do
+      null_ptr = FFI::Pointer::NULL
+      expect( null_ptr.read_array_of_uint(0) ).to eq([])
+      null_ptr.write_array_of_uint([])
+    end
   end
 
   it "Pointer.size returns sizeof pointer on platform" do


### PR DESCRIPTION
This changes array read and write methods to no longer raise a FFI::NullPointerError if there is actually no memory access.

Fixes #305