### PR TITLE
Fix FFI::Pointer#write_string to always terminate with a \0 byte

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -502,7 +502,7 @@ memory_read_array_of_string(int argc, VALUE* argv, VALUE self)
  * @raise {SecurityError} when writing unsafe string to memory
  * @raise {IndexError} if +offset+ is too great
  * @raise {NullPointerError} if memory not initialized
- * Put a string in memory.
+ * Put a string in memory. Writes a final \0 byte.
  */
 static VALUE
 memory_put_string(VALUE self, VALUE offset, VALUE str)

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -97,11 +97,15 @@ module FFI
     # @param [Numeric] len length of string to return
     # @return [self]
     # Write +str+ in pointer's contents, or first +len+ bytes if 
-    # +len+ is not +nil+.
+    # +len+ is not +nil+. A final \0 byte is written if +len+ is not given.
     def write_string(str, len=nil)
-      len = str.bytesize unless len
-      # Write the string data without NUL termination
-      put_bytes(0, str, 0, len)
+      if len
+        # No NUL termination
+        put_bytes(0, str, 0, len)
+      else
+        # With NUL termination
+        put_string(0, str)
+      end
     end unless method_defined?(:write_string)
 
     # @param [Type] type type of data to read from pointer's contents

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -102,7 +102,7 @@ module FFI
     def write_string(str, len=nil)
       if len
         if len == size
-          warn "[DEPRECATION] Memory to small to write a final 0-byte in #{caller[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
+          warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
           put_bytes(0, str, 0, len)
         else
           put_char(len, 0) # Check size before writing str
@@ -110,7 +110,7 @@ module FFI
         end
       else
         if str.bytesize == size
-          warn "[DEPRECATION] Memory to small to write a final 0-byte in #{caller[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
+          warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
           put_bytes(0, str)
         else
           put_string(0, str)

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -85,12 +85,12 @@ module FFI
     # @param [String] str string to write
     # @param [Numeric] len length of string to return
     # @return [self]
-    # Write +len+ first bytes of +str+ in pointer's contents.
+    # Write +len+ first bytes of +str+ in pointer's contents and a final \0 byte.
     #
     # Same as:
     #  ptr.write_string(str, len)   # with len not nil
     def write_string_length(str, len)
-      write_bytes(str, 0, len)
+      write_string(str, len)
     end unless method_defined?(:write_string_length)
 
     # @param [String] str string to write

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -101,10 +101,20 @@ module FFI
     # In both cases a final \0 byte is written after the string.
     def write_string(str, len=nil)
       if len
-        put_bytes(0, str, 0, len)
-        put_char(len, 0)
+        if len == size
+          warn "[DEPRECATION] Memory to small to write a final 0-byte in #{caller[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
+          put_bytes(0, str, 0, len)
+        else
+          put_char(len, 0) # Check size before writing str
+          put_bytes(0, str, 0, len)
+        end
       else
-        put_string(0, str)
+        if str.bytesize == size
+          warn "[DEPRECATION] Memory to small to write a final 0-byte in #{caller[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
+          put_bytes(0, str)
+        else
+          put_string(0, str)
+        end
       end
     end unless method_defined?(:write_string)
 

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -96,14 +96,14 @@ module FFI
     # @param [String] str string to write
     # @param [Numeric] len length of string to return
     # @return [self]
-    # Write +str+ in pointer's contents, or first +len+ bytes if 
-    # +len+ is not +nil+. A final \0 byte is written if +len+ is not given.
+    # Write +str+ in pointer's contents.
+    # If +len+ is given, write the first +len+ bytes of +str+
+    # and append a final \0 byte after the string.
     def write_string(str, len=nil)
       if len
-        # No NUL termination
         put_bytes(0, str, 0, len)
+        put_bytes(len, "\0")
       else
-        # With NUL termination
         put_string(0, str)
       end
     end unless method_defined?(:write_string)

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -90,7 +90,7 @@ module FFI
     # Same as:
     #  ptr.write_string(str, len)   # with len not nil
     def write_string_length(str, len)
-      put_bytes(0, str, 0, len)
+      write_bytes(str, 0, len)
     end unless method_defined?(:write_string_length)
 
     # @param [String] str string to write
@@ -103,15 +103,15 @@ module FFI
       if len
         if len == size
           warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
-          put_bytes(0, str, 0, len)
+          write_bytes(str, 0, len)
         else
           put_char(len, 0) # Check size before writing str
-          put_bytes(0, str, 0, len)
+          write_bytes(str, 0, len)
         end
       else
         if str.bytesize == size
           warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
-          put_bytes(0, str)
+          write_bytes(str)
         else
           put_string(0, str)
         end

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -97,12 +97,12 @@ module FFI
     # @param [Numeric] len length of string to return
     # @return [self]
     # Write +str+ in pointer's contents.
-    # If +len+ is given, write the first +len+ bytes of +str+
-    # and append a final \0 byte after the string.
+    # If +len+ is given, write the first +len+ bytes of +str+.
+    # In both cases a final \0 byte is written after the string.
     def write_string(str, len=nil)
       if len
         put_bytes(0, str, 0, len)
-        put_bytes(len, "\0")
+        put_char(len, 0)
       else
         put_string(0, str)
       end

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -96,4 +96,30 @@ describe "String tests" do
     ptrary.write_array_of_pointer(ary)
     expect { ptrary.get_array_of_string(-1) }.to raise_error(IndexError)
   end
+
+  describe "#write_string" do
+    it "does not write a final \\0 when given no length" do
+      ptr = FFI::MemoryPointer.new(8)
+      ptr.write_int64(-1)
+      ptr.write_string("abc")
+      expect(ptr.read_bytes(4)).to eq("abc\xFF".b)
+    end
+
+    it "does not write a final \\0 when given a length" do
+      ptr = FFI::MemoryPointer.new(8)
+      ptr.write_int64(-1)
+      ptr.write_string("abc", 3)
+      expect(ptr.read_bytes(4)).to eq("abc\xFF".b)
+    end
+  end
+
+  describe "#put_string" do
+    it "writes a final \\0" do
+      ptr = FFI::MemoryPointer.new(8)
+      ptr.write_int64(-1)
+      ptr.put_string(0, "abc")
+      expect(ptr.read_bytes(4)).to eq("abc\x00")
+      expect(ptr.read_string).to eq("abc")
+    end
+  end
 end

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -122,7 +122,7 @@ describe "String tests" do
           ptr = FFI::MemoryPointer.new(5)
           expect do
             ptr.write_string("äbcd")
-          end.to output(/memory to small/i).to_stderr
+          end.to output(/memory too small/i).to_stderr
           expect(ptr.read_string).to eq("äbcd".b)
         end
       else
@@ -158,7 +158,7 @@ describe "String tests" do
           ptr = FFI::MemoryPointer.new(5)
           expect do
             ptr.write_string("äbcde", 5)
-          end.to output(/memory to small/i).to_stderr
+          end.to output(/memory too small/i).to_stderr
           expect(ptr.read_string).to eq("äbcd".b)
         end
       else

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -99,19 +99,77 @@ describe "String tests" do
 
   describe "#write_string" do
     # https://github.com/ffi/ffi/issues/805
-    it "writes a final \\0 when given no length" do
-      ptr = FFI::MemoryPointer.new(8)
-      ptr.write_int64(-1)
-      ptr.write_string("äbc")
-      expect(ptr.read_bytes(5)).to eq("äbc\x00".b)
-      expect(ptr.read_string).to eq("äbc".b)
+    describe "with no length given" do
+      it "writes a final \\0" do
+        ptr = FFI::MemoryPointer.new(8)
+        ptr.write_int64(-1)
+        ptr.write_string("äbc")
+        expect(ptr.read_bytes(5)).to eq("äbc\x00".b)
+        expect(ptr.read_string).to eq("äbc".b)
+      end
+
+      it "doesn't write anything when size is exceeded" do
+        ptr = FFI::MemoryPointer.new(8)
+        ptr.write_int64(-1)
+        expect do
+          ptr.write_string("äbcdefgh")
+        end.to raise_error(IndexError, /out of bounds/i)
+        expect(ptr.read_int64).to eq(-1)
+      end
+
+      if FFI::VERSION < "2"
+        it "prints a warning if final \\0 doesn't fit into memory" do
+          ptr = FFI::MemoryPointer.new(5)
+          expect do
+            ptr.write_string("äbcd")
+          end.to output(/memory to small/i).to_stderr
+          expect(ptr.read_string).to eq("äbcd".b)
+        end
+      else
+        it "denies writing if final \\0 doesn't fit into memory" do
+          ptr = FFI::MemoryPointer.new(5)
+          expect do
+            ptr.write_string("äbcd")
+          end.to raise_error(IndexError, /out of bounds/i)
+          expect(ptr.read_string).to eq("".b)
+        end
+      end
     end
 
-    it "writes a final \\0 when given a length" do
-      ptr = FFI::MemoryPointer.new(8)
-      ptr.write_int64(-1)
-      ptr.write_string("äbcd", 3)
-      expect(ptr.read_bytes(5)).to eq("äb\x00\xFF".b)
+    describe "with a length" do
+      it "writes a final \\0" do
+        ptr = FFI::MemoryPointer.new(8)
+        ptr.write_int64(-1)
+        ptr.write_string("äbcd", 3)
+        expect(ptr.read_bytes(5)).to eq("äb\x00\xFF".b)
+      end
+
+      it "doesn't write anything when size is exceeded" do
+        ptr = FFI::MemoryPointer.new(8)
+        ptr.write_int64(-1)
+        expect do
+          ptr.write_string("äbcdefghi", 9)
+        end.to raise_error(IndexError, /out of bounds/i)
+        expect(ptr.read_int64).to eq(-1)
+      end
+
+      if FFI::VERSION < "2"
+        it "prints a warning if final \\0 doesn't fit into memory" do
+          ptr = FFI::MemoryPointer.new(5)
+          expect do
+            ptr.write_string("äbcde", 5)
+          end.to output(/memory to small/i).to_stderr
+          expect(ptr.read_string).to eq("äbcd".b)
+        end
+      else
+        it "denies writing if final \\0 doesn't fit into memory" do
+          ptr = FFI::MemoryPointer.new(5)
+          expect do
+            ptr.write_string("äbcde", 5)
+          end.to raise_error(IndexError, /out of bounds/i)
+          expect(ptr.read_string).to eq("".b)
+        end
+      end
     end
   end
 

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -98,11 +98,13 @@ describe "String tests" do
   end
 
   describe "#write_string" do
-    it "does not write a final \\0 when given no length" do
+    # https://github.com/ffi/ffi/issues/805
+    it "writes a final \\0 when given no length" do
       ptr = FFI::MemoryPointer.new(8)
       ptr.write_int64(-1)
       ptr.write_string("abc")
-      expect(ptr.read_bytes(4)).to eq("abc\xFF".b)
+      expect(ptr.read_bytes(4)).to eq("abc\x00")
+      expect(ptr.read_string).to eq("abc")
     end
 
     it "does not write a final \\0 when given a length" do

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -102,16 +102,16 @@ describe "String tests" do
     it "writes a final \\0 when given no length" do
       ptr = FFI::MemoryPointer.new(8)
       ptr.write_int64(-1)
-      ptr.write_string("abc")
-      expect(ptr.read_bytes(4)).to eq("abc\x00")
-      expect(ptr.read_string).to eq("abc")
+      ptr.write_string("äbc")
+      expect(ptr.read_bytes(5)).to eq("äbc\x00".b)
+      expect(ptr.read_string).to eq("äbc".b)
     end
 
-    it "does not write a final \\0 when given a length" do
+    it "writes a final \\0 when given a length" do
       ptr = FFI::MemoryPointer.new(8)
       ptr.write_int64(-1)
-      ptr.write_string("abc", 3)
-      expect(ptr.read_bytes(4)).to eq("abc\xFF".b)
+      ptr.write_string("äbcd", 3)
+      expect(ptr.read_bytes(5)).to eq("äb\x00\xFF".b)
     end
   end
 
@@ -119,9 +119,9 @@ describe "String tests" do
     it "writes a final \\0" do
       ptr = FFI::MemoryPointer.new(8)
       ptr.write_int64(-1)
-      ptr.put_string(0, "abc")
-      expect(ptr.read_bytes(4)).to eq("abc\x00")
-      expect(ptr.read_string).to eq("abc")
+      ptr.put_string(0, "äbc")
+      expect(ptr.read_bytes(5)).to eq("äbc\x00".b)
+      expect(ptr.read_string).to eq("äbc".b)
     end
   end
 end


### PR DESCRIPTION
* Add specs for FFI::Pointer#write_string and #put_string
* Fixes #805

There was no specs for `write_string` yet, so actually changing as proposed in #805 caused no spec failures.
