### PR TITLE
Use ffi_closure_alloc() on Apple silicon to fix crash

### DIFF
--- a/ext/ffi_c/ClosurePool.h
+++ b/ext/ffi_c/ClosurePool.h
@@ -36,6 +36,8 @@ struct Closure_ {
     void* info;      /* opaque handle for storing closure-instance specific data */
     void* function;  /* closure-instance specific function, called by custom trampoline */
     void* code;      /* The native trampoline code location */
+    void* pcl;
+
     struct ClosurePool_* pool;
     Closure* next;
 };

--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -844,7 +844,7 @@ callback_prep(void* ctx, void* code, Closure* closure, char* errmsg, size_t errm
     FunctionType* fnInfo = (FunctionType *) ctx;
     ffi_status ffiStatus;
 
-    ffiStatus = ffi_prep_closure_loc(code, &fnInfo->ffi_cif, callback_invoke, closure, code);
+    ffiStatus = ffi_prep_closure_loc(closure->pcl, &fnInfo->ffi_cif, callback_invoke, closure, code);
     if (ffiStatus != FFI_OK) {
         snprintf(errmsg, errmsgsize, "ffi_prep_closure_loc failed.  status=%#x", ffiStatus);
         return false;

--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -136,7 +136,7 @@ prep_trampoline(void* ctx, void* code, Closure* closure, char* errmsg, size_t er
 #if defined(USE_RAW)
     ffiStatus = ffi_prep_raw_closure(code, &mh_cif, attached_method_invoke, closure);
 #else
-    ffiStatus = ffi_prep_closure_loc(code, &mh_cif, attached_method_invoke, closure, code);
+    ffiStatus = ffi_prep_closure_loc(closure->pcl, &mh_cif, attached_method_invoke, closure, code);
 #endif
     if (ffiStatus != FFI_OK) {
         snprintf(errmsg, errmsgsize, "ffi_prep_closure_loc failed.  status=%#x", ffiStatus);

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -61,6 +61,9 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     File.open("Makefile", "a") do |mf|
       mf.puts "LIBFFI_HOST=--host=#{RbConfig::CONFIG['host_alias']}" if RbConfig::CONFIG.has_key?("host_alias")
       if RbConfig::CONFIG['host_os'].downcase =~ /darwin/
+        if RbConfig::CONFIG['host'] =~ /arm/
+          mf.puts "LIBFFI_HOST=--host=aarch64-apple-#{RbConfig::CONFIG['host_os']}"
+        end
         mf.puts "include ${srcdir}/libffi.darwin.mk"
       elsif RbConfig::CONFIG['host_os'].downcase =~ /bsd/
         mf.puts '.include "${srcdir}/libffi.bsd.mk"'


### PR DESCRIPTION
Fix #800

To prevent crashes, this patch will use `ffi_closure_alloc()` instead of `mmap()` when it run on the Apple silicon platform.
This patch provides another `rbffi_Closure_Alloc` for apple silicon (I'm afraid to affect to other platforms).


This patch needs #801 to succeed the `rake spec` on apple silicon.

Related to https://github.com/CocoaPods/CocoaPods/issues/9907