### PR TITLE
Add specs specific to Centos callback bug #621

### DIFF
--- a/spec/ffi/fork_spec.rb
+++ b/spec/ffi/fork_spec.rb
@@ -1,0 +1,41 @@
+#
+# This file is part of ruby-ffi.
+# For licensing, see LICENSE.SPECS
+#
+
+require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
+
+# Skip platforms that don't implement Process.fork
+unless RUBY_ENGINE == "truffleruby" or FFI::Platform.windows?
+  describe "Callback in conjunction with fork()" do
+
+    module LibTest
+      extend FFI::Library
+      ffi_lib TestLibrary::PATH
+
+      callback :cbVrL, [ ], :long
+      attach_function :testCallbackVrL, :testClosureVrL, [ :cbVrL ], :long
+    end
+
+    it "works with forked process and GC" do
+      expect(LibTest.testCallbackVrL { 12345 }).to eq(12345)
+      fork do
+        expect(LibTest.testCallbackVrL { 12345 }).to eq(12345)
+      end
+      expect(LibTest.testCallbackVrL { 12345 }).to eq(12345)
+      GC.start
+    end
+
+    it "works with forked process and free()" do
+      func = LibTest.ffi_libraries.first.find_function("testClosureVrL")
+      cbf = FFI::Function.new(FFI::Type::LONG, []) { 234 }
+
+      fork do
+        cbf.free
+      end
+
+      expect(LibTest.testCallbackVrL(cbf)).to eq(234)
+      cbf.free
+    end
+  end
+end


### PR DESCRIPTION
I forgot about these specs when fixing #621. They should be merged, to verify this use case in the future.