### PR TITLE
Fix memory leak in MethodHandle

### DIFF
--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -117,6 +117,7 @@ rbffi_MethodHandle_Free(MethodHandle* handle)
 {
     if (handle != NULL) {
         rbffi_Closure_Free(handle->closure);
+        xfree(handle);
     }
 }
 


### PR DESCRIPTION
`handle` has memory area allocated in `rbffi_MethodHandle_Alloc()`

https://github.com/ffi/ffi/blob/faae322f74969dfd9a64f767636fea9ed035bf85/ext/ffi_c/MethodHandle.c#L107

And it should be released.