### PR TITLE
Fixing error 'TypeError: unable to resolve type ...' on platform MSYS2

### DIFF
--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -50,7 +50,7 @@ module FFI
       "dragonflybsd"
     when /sunos|solaris/
       "solaris"
-    when /mingw|mswin/
+    when /mingw|mswin|msys/
       "windows"
     else
       RbConfig::CONFIG['host_os'].downcase


### PR DESCRIPTION
I'm not a Ruby developer, but just stumbled on issue
```
TypeError: unable to resolve type 'size_t'
  .gem/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi/types.rb:69:in `find_type'
  .gem/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi/library.rb:589:in `find_type'
  .gem/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi/struct.rb:277:in `find_type'
  .gem/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi/struct.rb:271:in `find_field_type'
  .gem/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi/struct.rb:311:in `array_layout'
  .gem/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi/struct.rb:217:in `layout'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native/sass_value.rb:53:in `<class:SassList>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native/sass_value.rb:52:in `<module:Native>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native/sass_value.rb:4:in `<module:SassC>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native/sass_value.rb:3:in `<top (required)>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native.rb:16:in `require_relative'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native.rb:16:in `<module:Native>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native.rb:6:in `<module:SassC>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc/native.rb:5:in `<top (required)>'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc.rb:31:in `require_relative'
  .gem/ruby/2.7.0/gems/sassc-2.4.0/lib/sassc.rb:31:in `<top (required)>'
  .gem/ruby/2.7.0/gems/jekyll-sass-converter-2.1.0/lib/jekyll/converters/scss.rb:3:in `require'
  .gem/ruby/2.7.0/gems/jekyll-sass-converter-2.1.0/lib/jekyll/converters/scss.rb:3:in `<top (required)>'
  .gem/ruby/2.7.0/gems/jekyll-sass-converter-2.1.0/lib/jekyll-sass-converter.rb:4:in `require'
  .gem/ruby/2.7.0/gems/jekyll-sass-converter-2.1.0/lib/jekyll-sass-converter.rb:4:in `<top (required)>'
  .gem/ruby/2.7.0/gems/jekyll-4.1.1/lib/jekyll.rb:209:in `require'
  .gem/ruby/2.7.0/gems/jekyll-4.1.1/lib/jekyll.rb:209:in `<top (required)>'
  .gem/ruby/2.7.0/gems/jekyll-4.1.1/exe/jekyll:8:in `require'
  .gem/ruby/2.7.0/gems/jekyll-4.1.1/exe/jekyll:8:in `<top (required)>'
  .gem/ruby/2.7.0/bin/jekyll:23:in `load'
  .gem/ruby/2.7.0/bin/jekyll:23:in `<top (required)>'
```
and thought instead of reporting the issue I just provide you with a quick fix. Thanks.