### PR TITLE
Check JRuby version without accessing Gem

### DIFF
--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -8,11 +8,11 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
 
   require 'ffi/ffi'
 
-elsif RUBY_ENGINE == 'jruby' && Gem::Version.new(RUBY_ENGINE_VERSION) >= Gem::Version.new("9.3.pre")
+elsif RUBY_ENGINE == 'jruby' && (RUBY_ENGINE_VERSION.split('.').map(&:to_i) <=> [9, 3]) >= 0
   JRuby::Util.load_ext("org.jruby.ext.ffi.FFIService")
   require 'ffi/ffi'
 
-elsif RUBY_ENGINE == 'truffleruby' && Gem::Version.new(RUBY_ENGINE_VERSION) >= Gem::Version.new("20.1.0-dev-a")
+elsif RUBY_ENGINE == 'truffleruby' && (RUBY_ENGINE_VERSION.split('.').map(&:to_i) <=> [20, 1, 0]) >= 0
   require 'truffleruby/ffi_backend'
   require 'ffi/ffi'
 


### PR DESCRIPTION
When running with --disable-gems, JRuby still needs to be able to load FFI from stdlib. Accessing the Gem namespace here requires that gems not be disabled.

This patch uses a simple split and integer comparison to compare the first two digits of the JRuby version with 9.3.

See #763 for the original code.

This patch is necessary for JRuby to fully source the FFI Ruby files from the gem (jruby/jruby#6150). Example failures here are due to the MRI suites running without RubyGems enabled, but they end up needing FFI for internal JRuby functionality.

https://travis-ci.org/github/jruby/jruby/builds/729197020

So close!