### PR TITLE
Adds method to check of pointer size if bounded

### DIFF
--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -315,6 +315,22 @@ ptr_address(VALUE self)
     return ULL2NUM((uintptr_t) ptr->memory.address);
 }
 
+/*
+ * Document-method: size_limit?
+ * call-seq: ptr.size_limit?
+ * @return [Boolean]
+ * Return +true+ if +self+ has a size limit.
+ */
+static VALUE
+ptr_size_limit(VALUE self)
+{
+    Pointer* ptr;
+
+    Data_Get_Struct(self, Pointer, ptr);
+
+    return ptr->memory.size == LONG_MAX ? Qfalse : Qtrue;
+}
+
 #if BYTE_ORDER == LITTLE_ENDIAN
 # define SWAPPED_ORDER BIG_ENDIAN
 #else
@@ -497,6 +513,7 @@ rbffi_Pointer_Init(VALUE moduleFFI)
     rb_define_method(rbffi_PointerClass, "autorelease?", ptr_autorelease_p, 0);
     rb_define_method(rbffi_PointerClass, "free", ptr_free, 0);
     rb_define_method(rbffi_PointerClass, "type_size", ptr_type_size, 0);
+    rb_define_method(rbffi_PointerClass, "size_limit?", ptr_size_limit, 0);
 
     rbffi_NullPointerSingleton = rb_class_new_instance(1, &rbNullAddress, rbffi_PointerClass);
     /*

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -228,6 +228,16 @@ describe "Pointer" do
       expect(pointer.read_int32).to eq(16909060)
     end
   end if RUBY_ENGINE != "truffleruby"
+
+  describe "#size_limit?" do
+    it "should not have size limit" do
+      expect(FFI::Pointer.new(0).size_limit?).to be false
+    end
+
+    it "should have size limit" do
+      expect(FFI::Pointer.new(0).slice(0, 10).size_limit?).to be true
+    end
+  end if RUBY_ENGINE != "truffleruby"
 end
 
 describe "AutoPointer" do


### PR DESCRIPTION
Hi, thanks for this great library!

This PR adds a method to tell if the pointer size is bounded.

```ruby
ptr = FFI::Pointer.new(0)
ptr.bounded?              # false
ptr.slice(0, 10).bounded? # true
```

This can be useful for libraries that accept `FFI::Pointer` arguments.

```ruby
def load_image(ptr, ...)
  raise "Cannot load image from pointer with unbounded size" unless ptr.bounded?
  # do something with size ...
end
```