### PR TITLE
Specify Pointer#order and Struct#order

### DIFF
--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -333,7 +333,7 @@ ptr_address(VALUE self)
  * @overload order(order)
  *  @param  [Symbol] order endianness to set (+:little+, +:big+ or +:network+). +:big+ and +:network+
  *   are synonymous.
- *  @return [self]
+ *  @return a new pointer with the new order
  */
 static VALUE
 ptr_order(int argc, VALUE* argv, VALUE self)

--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -358,6 +358,8 @@ ptr_order(int argc, VALUE* argv, VALUE self)
 
             } else if (id == rb_intern("big") || id == rb_intern("network")) {
                 order = BIG_ENDIAN;
+            } else {
+                rb_raise(rb_eArgError, "unknown byte order");
             }
         }
         if (order != BYTE_ORDER) {

--- a/spec/ffi/platform_spec.rb
+++ b/spec/ffi/platform_spec.rb
@@ -111,4 +111,27 @@ describe "FFI::Platform.unix?" do
       expect(FFI::Platform.unix?).to be true
     end
   end
+
+  describe "FFI::Platform::LITTLE_ENDIAN" do
+    it "returns 1234" do
+      expect(FFI::Platform::LITTLE_ENDIAN).to eq(1234)
+    end
+  end
+
+  describe "FFI::Platform::BIG_ENDIAN" do
+    it "returns 4321" do
+      expect(FFI::Platform::BIG_ENDIAN).to eq(4321)
+    end
+  end
+
+  describe "FFI::Platform::BYTE_ORDER" do
+    it "returns the current byte order" do
+      if [1234].pack("I") == [1234].pack("N")
+        order = FFI::Platform::BIG_ENDIAN
+      else
+        order = FFI::Platform::LITTLE_ENDIAN
+      end
+      expect(FFI::Platform::BYTE_ORDER).to eq(order)
+    end
+  end
 end

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -181,6 +181,53 @@ describe "Pointer" do
       expect(FFI::MemoryPointer.new(:int, 1).type_size).to eq(FFI.type_size(:int))
     end
   end
+
+  describe "#order" do
+    it "should return the system order by default" do
+      expect(FFI::Pointer.new(0x0).order).to eq(OrderHelper::ORDER)
+    end
+
+    it "should return self if there is no change" do
+      pointer = FFI::Pointer.new(0x0)
+      expect(pointer.order(OrderHelper::ORDER)).to be pointer
+    end
+
+    it "should return a new pointer if there is a change" do
+      pointer = FFI::Pointer.new(0x0)
+      expect(pointer.order(OrderHelper::OTHER_ORDER)).to_not be pointer
+    end
+
+    it "can be set to :little" do
+      expect(FFI::Pointer.new(0x0).order(:little).order).to eq(:little)
+    end
+
+    it "can be set to :big" do
+      expect(FFI::Pointer.new(0x0).order(:big).order).to eq(:big)
+    end
+
+    it "can be set to :network, which sets it to :big" do
+      expect(FFI::Pointer.new(0x0).order(:network).order).to eq(:big)
+    end
+
+    it "cannot be set to other symbols" do
+      expect { FFI::Pointer.new(0x0).order(:unknown) }.to raise_error(ArgumentError)
+    end
+
+    it "can be used to read in little order" do
+      pointer = FFI::MemoryPointer.from_string("\x1\x2\x3\x4").order(:little)
+      expect(pointer.read_int32).to eq(67305985)
+    end
+
+    it "can be used to read in big order" do
+      pointer = FFI::MemoryPointer.from_string("\x1\x2\x3\x4").order(:big)
+      expect(pointer.read_int32).to eq(16909060)
+    end
+
+    it "can be used to read in network order" do
+      pointer = FFI::MemoryPointer.from_string("\x1\x2\x3\x4").order(:network)
+      expect(pointer.read_int32).to eq(16909060)
+    end
+  end
 end
 
 describe "AutoPointer" do

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -43,3 +43,16 @@ def external_run(cmd, rb_file, options: [], timeout: 10)
   end
   File.read(log)
 end
+
+module OrderHelper
+  case FFI::Platform::BYTE_ORDER
+  when FFI::Platform::LITTLE_ENDIAN
+    ORDER = :little
+    OTHER_ORDER = :big
+  when FFI::Platform::BIG_ENDIAN
+    ORDER = :big
+    OTHER_ORDER = :little
+  else
+    raise
+  end
+end

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -1026,4 +1026,58 @@ describe "variable-length arrays" do
     expect { expect(s[:data][1]).to == 0x12345678 }.to raise_error(IndexError)
   end
 end
+
+describe "Struct order" do
+  before :all do
+    @struct = Class.new(FFI::Struct) do
+      layout :value, :int32
+    end
+  end
+
+  before :each do
+    @pointer = @struct.new
+    @pointer.pointer.write_string("\x1\x2\x3\x4")
+    @pointer
+  end
+
+  it "should return the system order by default" do
+    expect(@pointer.order).to eq(OrderHelper::ORDER)
+  end
+
+  it "should return a new struct if there is no change" do
+    expect(@pointer.order(OrderHelper::ORDER)).to_not be @pointer
+  end
+
+  it "should return a new struct if there is a change" do
+    expect(@pointer.order(OrderHelper::OTHER_ORDER)).to_not be @pointer
+  end
+
+  it "can be set to :little" do
+    expect(@pointer.order(:little).order).to eq(:little)
+  end
+
+  it "can be set to :big" do
+    expect(@pointer.order(:big).order).to eq(:big)
+  end
+
+  it "can be set to :network, which sets it to :big" do
+    expect(@pointer.order(:network).order).to eq(:big)
+  end
+
+  it "cannot be set to other symbols" do
+    expect { @pointer.order(:unknown) }.to raise_error(ArgumentError)
+  end
+
+  it "can be used to read in little order" do
+    expect(@pointer.order(:little)[:value]).to eq(67305985)
+  end
+
+  it "can be used to read in big order" do
+    expect(@pointer.order(:big)[:value]).to eq(16909060)
+  end
+
+  it "can be used to read in network order" do
+    expect(@pointer.order(:network)[:value]).to eq(16909060)
+  end
+end
 end

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -1036,7 +1036,7 @@ describe "Struct order" do
 
   before :each do
     @pointer = @struct.new
-    @pointer.pointer.write_string("\x1\x2\x3\x4")
+    @pointer.pointer.write_bytes("\x1\x2\x3\x4")
     @pointer
   end
 


### PR DESCRIPTION
Also slight clarify documentation on `Pointer#order`, raise on an unknown order, and specify `Platform::BYTE_ORDER` etc.

Working towards https://github.com/oracle/truffleruby/issues/2054.