### PR TITLE
Define endian constants and fix CI on TruffleRuby

### DIFF
--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -144,6 +144,12 @@ module FFI
       "#{LIBPREFIX}c.#{LIBSUFFIX}"
     end
 
+    LITTLE_ENDIAN = 1234 unless defined?(LITTLE_ENDIAN)
+    BIG_ENDIAN = 4321 unless defined?(BIG_ENDIAN)
+    unless defined?(BYTE_ORDER)
+      BYTE_ORDER = [0x12345678].pack("I") == [0x12345678].pack("N") ? BIG_ENDIAN : LITTLE_ENDIAN
+    end
+
     # Test if current OS is a *BSD (include MAC)
     # @return [Boolean]
     def self.bsd?

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -227,7 +227,7 @@ describe "Pointer" do
       pointer = FFI::MemoryPointer.from_string("\x1\x2\x3\x4").order(:network)
       expect(pointer.read_int32).to eq(16909060)
     end
-  end
+  end if RUBY_ENGINE != "truffleruby"
 end
 
 describe "AutoPointer" do

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -1079,5 +1079,5 @@ describe "Struct order" do
   it "can be used to read in network order" do
     expect(@pointer.order(:network)[:value]).to eq(16909060)
   end
-end
+end if RUBY_ENGINE != "truffleruby"
 end


### PR DESCRIPTION
Follow-up of https://github.com/oracle/truffleruby/issues/2054.

@larskanis https://github.com/ffi/ffi/blob/234ebce58eb179035c1c0568f198d34b75f7eb90/ext/ffi_c/rbffi_endian.h seems more verbose/complicated than the Ruby code to define these 3 constants, should we remove that file and always let Ruby code define them? The specs already check that LITTLE_ENDIAN is 1234 and BIG_ENDIAN is 4321, so at least that's valid for all platforms tested in CI.
Also the `pack()` check seems more reliable than a series of `#ifdef`.
We still need `unless defined?` checks for JRuby which defines them in the Java extension.

cc @chrisseaton 