### PR TITLE
Move Pointer#size_limit? to AbstractMemory and from C to ruby

### DIFF
--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -315,22 +315,6 @@ ptr_address(VALUE self)
     return ULL2NUM((uintptr_t) ptr->memory.address);
 }
 
-/*
- * Document-method: size_limit?
- * call-seq: ptr.size_limit?
- * @return [Boolean]
- * Return +true+ if +self+ has a size limit.
- */
-static VALUE
-ptr_size_limit(VALUE self)
-{
-    Pointer* ptr;
-
-    Data_Get_Struct(self, Pointer, ptr);
-
-    return ptr->memory.size == LONG_MAX ? Qfalse : Qtrue;
-}
-
 #if BYTE_ORDER == LITTLE_ENDIAN
 # define SWAPPED_ORDER BIG_ENDIAN
 #else
@@ -513,7 +497,6 @@ rbffi_Pointer_Init(VALUE moduleFFI)
     rb_define_method(rbffi_PointerClass, "autorelease?", ptr_autorelease_p, 0);
     rb_define_method(rbffi_PointerClass, "free", ptr_free, 0);
     rb_define_method(rbffi_PointerClass, "type_size", ptr_type_size, 0);
-    rb_define_method(rbffi_PointerClass, "size_limit?", ptr_size_limit, 0);
 
     rbffi_NullPointerSingleton = rb_class_new_instance(1, &rbNullAddress, rbffi_PointerClass);
     /*

--- a/lib/ffi/abstract_memory.rb
+++ b/lib/ffi/abstract_memory.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2010 JRuby project
+# Copyright (C) 2020 Lars Kanis
 #
 # This file is part of ruby-ffi.
 #
@@ -26,22 +26,19 @@
 # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.#
 
-require 'ffi/platform'
-require 'ffi/data_converter'
-require 'ffi/types'
-require 'ffi/library'
-require 'ffi/errno'
-require 'ffi/abstract_memory'
-require 'ffi/pointer'
-require 'ffi/memorypointer'
-require 'ffi/struct'
-require 'ffi/union'
-require 'ffi/managedstruct'
-require 'ffi/callback'
-require 'ffi/io'
-require 'ffi/autopointer'
-require 'ffi/variadic'
-require 'ffi/enum'
-require 'ffi/version'
+
+module FFI
+  class AbstractMemory
+    LONG_MAX = FFI::Pointer.new(1).size
+    private_constant :LONG_MAX
+
+    # Return +true+ if +self+ has a size limit.
+    #
+    # @return [Boolean]
+    def size_limit?
+      size != LONG_MAX
+    end
+  end
+end

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -236,7 +236,7 @@ describe "Pointer" do
     it "should have size limit" do
       expect(FFI::Pointer.new(0).slice(0, 10).size_limit?).to be true
     end
-  end if RUBY_ENGINE != "truffleruby"
+  end
 end
 
 describe "AutoPointer" do


### PR DESCRIPTION
Since size is defined in AbstractMemory, size_limit? should be there as well.

Moving to Ruby code ensures that it works on JRuby and Truffleruby.