### PR TITLE
Fix specs for Ruby 2.x on darwin-arm64

### DIFF
--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -23,7 +23,11 @@ module TestLibrary
     when /ppc|powerpc/
       "powerpc"
     when /^arm/
-      "arm"
+      if RbConfig::CONFIG['host_os'] =~ /darwin/
+        "aarch64"
+      else
+        "arm"
+      end
     else
       RbConfig::CONFIG['host_cpu']
     end


### PR DESCRIPTION
Use the workaround from #843 in the specs, so the result matches for arm64 on macOS.

Needed because Ruby versions prior to 3.0 return "arm" instead of "arm64" for `RbConfig::CONFIG['host_cpu']`.