### PR TITLE
Fix possible segfault in combination with fiddle or other libffi using gems

### DIFF
--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -50,6 +50,11 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   else
     $defs << "-DHAVE_FFI_PREP_CIF_VAR"
     $defs << "-DUSE_INTERNAL_LIBFFI"
+
+    # Ensure libffi symbols aren't exported when using static libffi.
+    # This is to avoid interference with other gems like fiddle.
+    # See https://github.com/ffi/ffi/issues/835
+    append_ldflags "-Wl,--exclude-libs,ALL"
   end
 
   ffi_alloc_default = RbConfig::CONFIG['host_os'] =~ /darwin/i && RbConfig::CONFIG['host'] =~ /arm/i


### PR DESCRIPTION
Fiddle can crash when used together with ffi and it's builtin libffi. This happens because fiddle is linked to system libffi, but ffi is linked to builtin libffi. Depending on which of these gems is loaded first, they link to the wrong runtime library.

This issue is similar to the issue in nokogiri: https://github.com/sparklemotion/nokogiri/issues/1959

Fixes #835