### PR TITLE
Warn and do not append \0 for FFI::Pointer#write_string(str, str.bytesize)

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -101,7 +101,7 @@ module FFI
     # In both cases a final \0 byte is written after the string.
     def write_string(str, len=nil)
       if len
-        if len == size
+        if len == size or str.bytesize == len
           warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
           write_bytes(str, 0, len)
         else

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -163,6 +163,16 @@ describe "String tests" do
           end.to output(/memory too small/i).to_stderr
           expect(ptr.read_string).to eq("äbcd".b)
         end
+
+        it "prints a warning if the given len is the same as str.bytesize and does not write \\0" do
+          ptr = FFI::MemoryPointer.new(30)
+          ptr.put_uint8(5, 42)
+          expect do
+            ptr.write_string("äbcd", 5)
+          end.to output(/memory too small/i).to_stderr
+          expect(ptr.read_bytes(5)).to eq("äbcd".b)
+          expect(ptr.get_uint8(5)).to eq(42)
+        end
       else
         it "denies writing if final \\0 doesn't fit into memory" do
           ptr = FFI::MemoryPointer.new(5)


### PR DESCRIPTION
* Fixes https://github.com/ffi/ffi/issues/857