### PR TITLE
Do not append \0 for FFI::Pointer#write_string(str, str.bytesize)

### DIFF
--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -101,13 +101,8 @@ module FFI
     # In both cases a final \0 byte is written after the string.
     def write_string(str, len=nil)
       if len
-        if len == size
-          warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."
-          write_bytes(str, 0, len)
-        else
-          put_char(len, 0) # Check size before writing str
-          write_bytes(str, 0, len)
-        end
+        warn "[DEPRECATION] #{caller(1, 1)[0]}: write_string(str, len) is deprecated, please use write_bytes(str, 0, len) instead. If you intend to append a \\0, use an additional put_char or use write_string(str.byteslice(0, len))."
+        write_bytes(str, 0, len)
       else
         if str.bytesize == size
           warn "[DEPRECATION] Memory too small to write a final 0-byte in #{caller(1, 1)[0]}. This will raise an error in ffi-2.0. Please use write_bytes instead or enlarge the memory region."

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -139,38 +139,24 @@ describe "String tests" do
     end
 
     describe "with a length" do
-      it "writes a final \\0" do
+      it "warns and does not write a final \\0" do
         ptr = FFI::MemoryPointer.new(8)
         ptr.write_int64(-1)
-        ptr.write_string("äbcd", 3)
-        expect(ptr.read_bytes(5)).to eq("äb\x00\xFF".b)
+        expect do
+          ptr.write_string("äbcd", 3)
+        end.to output(/write_string\(str, len\) is deprecated/i).to_stderr
+        expect(ptr.read_bytes(5)).to eq("äb\xFF\xFF".b)
       end
 
       it "doesn't write anything when size is exceeded" do
         ptr = FFI::MemoryPointer.new(8)
         ptr.write_int64(-1)
         expect do
-          ptr.write_string("äbcdefghi", 9)
-        end.to raise_error(IndexError, /out of bounds/i)
-        expect(ptr.read_int64).to eq(-1)
-      end
-
-      if FFI::VERSION < "2"
-        it "prints a warning if final \\0 doesn't fit into memory" do
-          ptr = FFI::MemoryPointer.new(5)
           expect do
-            ptr.write_string("äbcde", 5)
-          end.to output(/memory too small/i).to_stderr
-          expect(ptr.read_string).to eq("äbcd".b)
-        end
-      else
-        it "denies writing if final \\0 doesn't fit into memory" do
-          ptr = FFI::MemoryPointer.new(5)
-          expect do
-            ptr.write_string("äbcde", 5)
+            ptr.write_string("äbcdefghi", 9)
           end.to raise_error(IndexError, /out of bounds/i)
-          expect(ptr.read_string).to eq("".b)
-        end
+        end.to output(/write_string\(str, len\) is deprecated/i).to_stderr
+        expect(ptr.read_int64).to eq(-1)
       end
     end
   end


### PR DESCRIPTION
* Fixes https://github.com/ffi/ffi/issues/857