### PR TITLE
dynlib support for homebrew 3 on Apple Silicon M1

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -126,7 +126,7 @@ module FFI
               else
                 # TODO better library lookup logic
                 unless libname.start_with?("/") || FFI::Platform.windows?
-                  path = ['/usr/lib/','/usr/local/lib/','/opt/local/lib/'].find do |pth|
+                  path = ['/usr/lib/','/usr/local/lib/','/opt/local/lib/', '/opt/homebrew/lib/'].find do |pth|
                     File.exist?(pth + libname)
                   end
                   if path


### PR DESCRIPTION
As the homebrew team discussed in https://github.com/Homebrew/brew/issues/9177 the new library path for homebrew on apple silicon is `/opt/homebrew/lib`. Alongside the PR to support MacPorts https://github.com/ffi/ffi/pull/638 this commits adds support for the new homebrew path.

Fixes #880