### PR TITLE
Name the async_cb_thread for easier debugging

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -310,7 +310,7 @@ function_init(VALUE self, VALUE rbFunctionInfo, VALUE rbProc)
 #if defined(DEFER_ASYNC_CALLBACK)
         if (async_cb_thread == Qnil) {
             async_cb_thread = rb_thread_create(async_cb_event, NULL);
-            // Name thread, for better debugging
+            /* Name thread, for better debugging */
             rb_funcall(async_cb_thread, rb_intern("name="), 1, rb_str_new2("FFI::Function Callback Dispatcher"));
         }
 #endif
@@ -527,7 +527,9 @@ async_cb_event(void* unused)
         rb_thread_call_without_gvl(async_cb_wait, &w, async_cb_stop, &w);
         if (w.cb != NULL) {
             /* Start up a new ruby thread to run the ruby callback */
-            rb_thread_create(async_cb_call, w.cb);
+            VALUE new_thread = rb_thread_create(async_cb_call, w.cb);
+            /* Name thread, for better debugging */
+            rb_funcall(new_thread, rb_intern("name="), 1, rb_str_new2("FFI::Function Callback Runner"));
         }
     }
 

--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -310,6 +310,8 @@ function_init(VALUE self, VALUE rbFunctionInfo, VALUE rbProc)
 #if defined(DEFER_ASYNC_CALLBACK)
         if (async_cb_thread == Qnil) {
             async_cb_thread = rb_thread_create(async_cb_event, NULL);
+            // Name thread, for better debugging
+            rb_funcall(async_cb_thread, rb_intern("name="), 1, rb_str_new2("FFI::Function Callback Dispatcher"));
         }
 #endif
 

--- a/spec/ffi/async_callback_spec.rb
+++ b/spec/ffi/async_callback_spec.rb
@@ -39,10 +39,10 @@ describe "async callback" do
     skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
     skip "not yet supported on JRuby" if RUBY_ENGINE == "jruby"
 
-    thread_name = nil
+    callback_runner_thread = nil
 
-    LibTest.testAsyncCallback(proc { thread_name = Thread.current.name }, 0)
+    LibTest.testAsyncCallback(proc { callback_runner_thread = Thread.current }, 0)
 
-    expect(thread_name).to eq("FFI::Function Callback Runner")
+    expect(callback_runner_thread.name).to eq("FFI::Function Callback Runner")
   end
 end

--- a/spec/ffi/async_callback_spec.rb
+++ b/spec/ffi/async_callback_spec.rb
@@ -34,4 +34,15 @@ describe "async callback" do
     expect(called).to be true
     expect(v).to eq(0x7fffffff)
   end
+
+  it "sets the name of the thread that runs the callback" do
+    skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
+    skip "not yet supported on JRuby" if RUBY_ENGINE == "jruby"
+
+    thread_name = nil
+
+    LibTest.testAsyncCallback(proc { thread_name = Thread.current.name }, 0)
+
+    expect(thread_name).to eq("FFI::Function Callback Runner")
+  end
 end

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -21,6 +21,14 @@ describe FFI::Function do
     expect(fn.call).to eql 5
   end
 
+  context 'when called with a block' do
+    it 'creates a thread for dispatching callbacks and sets its name' do
+      FFI::Function.new(:int, []) { 5 } # Trigger initialization
+
+      expect(Thread.list.map(&:name)).to include("FFI::Function Callback Dispatcher")
+    end
+  end
+
   it 'raises an error when passing a wrong signature' do
     expect { FFI::Function.new([], :int).new { } }.to raise_error TypeError
   end

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -23,12 +23,10 @@ describe FFI::Function do
 
   context 'when called with a block' do
     it 'creates a thread for dispatching callbacks and sets its name' do
-      skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
-      skip "not yet supported on JRuby" if RUBY_ENGINE == 'jruby'
-
+      skip 'this is MRI-specific' if RUBY_ENGINE == 'truffleruby' || RUBY_ENGINE == 'jruby'
       FFI::Function.new(:int, []) { 5 } # Trigger initialization
 
-      expect(Thread.list.map(&:name)).to include("FFI::Function Callback Dispatcher")
+      expect(Thread.list.map(&:name)).to include('FFI::Function Callback Dispatcher')
     end
   end
 

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -24,6 +24,7 @@ describe FFI::Function do
   context 'when called with a block' do
     it 'creates a thread for dispatching callbacks and sets its name' do
       skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
+      skip "not yet supported on JRuby" if RUBY_ENGINE == 'jruby'
 
       FFI::Function.new(:int, []) { 5 } # Trigger initialization
 

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -23,6 +23,8 @@ describe FFI::Function do
 
   context 'when called with a block' do
     it 'creates a thread for dispatching callbacks and sets its name' do
+      skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
+
       FFI::Function.new(:int, []) { 5 } # Trigger initialization
 
       expect(Thread.list.map(&:name)).to include("FFI::Function Callback Dispatcher")


### PR DESCRIPTION
I found this useful while reviewing datadog/dd-trace-rb#1371 -- we were searching for specs that leaked threads, and saw a "mysterious" thread with no stack that we couldn't exactly point out what created it or why it existed.

By setting a name on the callback thread, it becomes immediately obvious when looking at `Thread.list` what this thread is and where it comes from.

(Thread naming has been around [since Ruby 2.3](https://github.com/ruby/ruby/blob/v2_3_0/NEWS) which means we can do it safely for every supported version)