### PR TITLE
Allow to pass callbacks in varargs

### DIFF
--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -49,6 +49,7 @@ module CallbackSpecs
       callback :cbVrU32, [ ], :uint
       callback :cbVrL, [ ], :long
       callback :cbVrUL, [ ], :ulong
+      callback :cbVrD, [ ], :double
       callback :cbVrS64, [ ], :long_long
       callback :cbVrU64, [ ], :ulong_long
       callback :cbVrP, [], :pointer
@@ -86,7 +87,7 @@ module CallbackSpecs
       attach_variable :pVrS8, :gvar_pointer, :pointer
       attach_function :testGVarCallbackVrS8, :testClosureVrB, [ :pointer ], :char
       attach_function :testOptionalCallbackCrV, :testOptionalClosureBrV, [ :cbCrV, :char ], :void
-
+      attach_function :testCallbackVrDva, :testClosureVrDva, [ :double, :varargs ], :double
     end
 
     it "returning :char (0)" do
@@ -259,6 +260,11 @@ module CallbackSpecs
 
     it "returning bool" do
       expect(LibTest.testCallbackVrZ { true }).to be true
+    end
+
+    it "returning double" do
+      pr = proc { 42.0 }
+      expect(LibTest.testCallbackVrDva(3.0, :cbVrD, pr)).to eq(45.0)
     end
 
     it "returning :pointer (nil)" do

--- a/spec/ffi/fixtures/ClosureTest.c
+++ b/spec/ffi/fixtures/ClosureTest.c
@@ -6,12 +6,24 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdarg.h>
 #ifndef _WIN32
 # include <pthread.h>
 #else
 # include <windows.h>
 # include <process.h>
 #endif
+
+double testClosureVrDva(double d, ...) {
+    va_list args;
+    double (*closure)(void);
+
+    va_start(args, d);
+    closure = va_arg(args, double (*)(void));
+    va_end(args);
+
+    return d + closure();
+}
 
 #define R(T, rtype) rtype testClosureVr##T(rtype (*closure)(void)) { \
     return closure != NULL ? (*closure)() : (rtype) 0; \


### PR DESCRIPTION
As I explained in https://github.com/ffi/ffi/issues/732#issuecomment-784703145, if you passed callbacks in varargs, a `NULL` pointer would be dereferenced and your program would crash.
I modified `variadic_invoke` to pass proper `callbackParameters` and `callbackCount` to `rbffi_SetupCallParams`, and that seems to fix the problem.