### PR TITLE
Fix async callbacks in conjunction with fork()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 Fixed:
 * Fix MSVC build
+* Fix async callbacks in conjunction with fork(). #884
 
 Added:
 * Allow to pass callbacks in varargs. #885

--- a/spec/ffi/fork_spec.rb
+++ b/spec/ffi/fork_spec.rb
@@ -8,21 +8,26 @@ require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
 if Process.respond_to?(:fork)
   describe "Callback in conjunction with fork()" do
 
-    module LibTest
+    libtest = Module.new do
       extend FFI::Library
       ffi_lib TestLibrary::PATH
 
       callback :cbVrL, [ ], :long
       attach_function :testCallbackVrL, :testClosureVrL, [ :cbVrL ], :long
+      AsyncIntCallback = callback [ :int ], :void
+      attach_function :testAsyncCallback, [ AsyncIntCallback, :int ], :void, blocking: true
     end
 
     it "works with forked process and GC" do
-      expect(LibTest.testCallbackVrL { 12345 }).to eq(12345)
+      expect(libtest.testCallbackVrL { 12345 }).to eq(12345)
       fork do
-        expect(LibTest.testCallbackVrL { 12345 }).to eq(12345)
+        expect(libtest.testCallbackVrL { 12345 }).to eq(12345)
+        Process.exit 42
       end
-      expect(LibTest.testCallbackVrL { 12345 }).to eq(12345)
+      expect(libtest.testCallbackVrL { 12345 }).to eq(12345)
       GC.start
+
+      expect(Process.wait2[1].exitstatus).to eq(42)
     end
 
     it "works with forked process and free()" do
@@ -30,10 +35,32 @@ if Process.respond_to?(:fork)
 
       fork do
         cbf.free
+        Process.exit 43
       end
 
-      expect(LibTest.testCallbackVrL(cbf)).to eq(234)
+      expect(libtest.testCallbackVrL(cbf)).to eq(234)
       cbf.free
+
+      expect(Process.wait2[1].exitstatus).to eq(43)
+    end
+
+    def run_async_callback(libtest)
+      recv = nil
+      libtest.testAsyncCallback(proc { |r| recv = r }, 23)
+      expect(recv).to eq(23)
+    end
+
+    it "async thread dispatch works after forking" do
+      run_async_callback(libtest)
+
+      fork do
+        run_async_callback(libtest)
+        Process.exit 44
+      end
+
+      run_async_callback(libtest)
+
+      expect(Process.wait2[1].exitstatus).to eq(44)
     end
   end
 end


### PR DESCRIPTION
After fork() the dispatcher thread is no longer running, so it needs to be restarted in the child process.

Fixes #884