### PR TITLE
Allow overriding `gcc` with the `CC` env var in `const_generator.rb` and `struct_generator.rb`

### DIFF
--- a/lib/ffi/tools/const_generator.rb
+++ b/lib/ffi/tools/const_generator.rb
@@ -124,7 +124,8 @@ module FFI
         f.puts "\n\treturn 0;\n}"
         f.flush
 
-        output = `gcc #{options[:cppflags]} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} 2>&1`
+        cc = ENV['CC'] || 'gcc'
+        output = `#{cc} #{options[:cppflags]} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} 2>&1`
 
         unless $?.success? then
           output = output.split("\n").map { |l| "\t#{l}" }.join "\n"

--- a/lib/ffi/tools/struct_generator.rb
+++ b/lib/ffi/tools/struct_generator.rb
@@ -82,7 +82,8 @@ module FFI
         f.puts "\n  return 0;\n}"
         f.flush
 
-        output = `gcc #{options[:cppflags]} #{options[:cflags]} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} 2>&1`
+        cc = ENV['CC'] || 'gcc'
+        output = `#{cc} #{options[:cppflags]} #{options[:cflags]} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} 2>&1`
 
         unless $?.success? then
           @found = false


### PR DESCRIPTION
Right now one can override `gcc` for `types_generator.rb`, but not `const_generator.rb` and `struct_generator.rb`. This PR fixes this.

Related: https://github.com/typhoeus/ethon/issues/186