### PR TITLE
Use arm or aarch64 to identify Apple ARM CPU arch

### DIFF
--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -57,7 +57,7 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     append_ldflags "-Wl,--exclude-libs,ALL"
   end
 
-  ffi_alloc_default = RbConfig::CONFIG['host_os'] =~ /darwin/i && RbConfig::CONFIG['host'] =~ /arm/i
+  ffi_alloc_default = RbConfig::CONFIG['host_os'] =~ /darwin/i && RbConfig::CONFIG['host'] =~ /arm|aarch64/i
   if enable_config('libffi-alloc', ffi_alloc_default)
     $defs << "-DUSE_FFI_ALLOC"
   end
@@ -71,7 +71,7 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     File.open("Makefile", "a") do |mf|
       mf.puts "LIBFFI_HOST=--host=#{RbConfig::CONFIG['host_alias']}" if RbConfig::CONFIG.has_key?("host_alias")
       if RbConfig::CONFIG['host_os'] =~ /darwin/i
-        if RbConfig::CONFIG['host'] =~ /arm/i
+        if RbConfig::CONFIG['host'] =~ /arm|aarch64/i
           mf.puts "LIBFFI_HOST=--host=aarch64-apple-#{RbConfig::CONFIG['host_os']}"
         end
         mf.puts "include ${srcdir}/libffi.darwin.mk"


### PR DESCRIPTION
Some versions of Ruby are identifying Apple M1 hosts as 'arm-apple-darwin20.3.0' and others 'aarch64-apple-darwin20.3.0'.

* Ruby 2.6.5 - `RbConfig::CONFIG['host'] == 'arm-apple-darwin20.3.0'`
* Ruby 2.6.7 - `RbConfig::CONFIG['host'] == 'aarch64-apple-darwin20.3.0'`