### PR TITLE
Fix Windows libc detection for MSYS2-ucrt build

### DIFF
--- a/bench/bench_time.rb
+++ b/bench/bench_time.rb
@@ -4,7 +4,7 @@ module BenchTime
   module Posix
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
-    if RUBY_PLATFORM =~ /mswin/
+    if RUBY_PLATFORM =~ /mswin/ || FFI::Library::LIBC =~ /ucrt/
       attach_function :time, :_time64, [ :buffer_out ], :uint64, ignore_error: true
     else
       attach_function :time, [ :buffer_out ], :ulong, ignore_error: true

--- a/bench/bench_time.rb
+++ b/bench/bench_time.rb
@@ -4,7 +4,7 @@ module BenchTime
   module Posix
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
-    if RUBY_PLATFORM =~ /mswin/ || FFI::Library::LIBC =~ /ucrt/
+    if FFI::Library::LIBC =~ /ucrtbase/
       attach_function :time, :_time64, [ :buffer_out ], :uint64, ignore_error: true
     else
       attach_function :time, [ :buffer_out ], :ulong, ignore_error: true

--- a/lib/ffi/platform.rb
+++ b/lib/ffi/platform.rb
@@ -132,11 +132,8 @@ module FFI
     end
 
     LIBC = if IS_WINDOWS
-      if RbConfig::CONFIG['host_os'] =~ /mingw/i
-        RbConfig::CONFIG['RUBY_SO_NAME'].split('-')[-2] + '.dll'
-      else
-        "ucrtbase.dll"
-      end
+      crtname = RbConfig::CONFIG["RUBY_SO_NAME"][/msvc\w+/] || 'ucrtbase'
+      "#{crtname}.dll"
     elsif IS_GNU
       GNU_LIBC
     elsif OS == 'cygwin'


### PR DESCRIPTION
Take the same approach for detection as used in fiddle:
  https://github.com/ruby/ruby/blob/79717f81f8ba24960cca6c934d00c72db64139ed/test/fiddle/helper.rb#L55-L56