### PR TITLE
CI: Install libffi which matches running arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,12 @@ jobs:
       with:
         ruby-version: 2.7
 
-    - run: brew install automake libffi pkg-config
-      if: matrix.os == 'macos'
-    - run: ridk exec sh -c "pacman --sync --refresh --needed --noconfirm  ${MINGW_PACKAGE_PREFIX}-libffi"
-      if: matrix.os == 'windows' && matrix.extconfopts == '--enable-system-libffi'
+    - if: matrix.os == 'macos'
+      run: brew install automake libffi pkg-config
+
+    - if: matrix.os == 'windows' && matrix.extconfopts == '--enable-system-libffi'
+      shell: cmd
+      run: ridk exec sh -c "pacman --sync --refresh --needed --noconfirm  ${MINGW_PACKAGE_PREFIX}-libffi"
 
     - run: bundle install
     - run: bundle exec rake libffi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     - run: brew install automake libffi pkg-config
       if: matrix.os == 'macos'
-    - run: ridk exec pacman --sync --refresh --needed --noconfirm  mingw-w64-x86_64-libffi
+    - run: ridk exec sh -c "pacman --sync --refresh --needed --noconfirm  ${MINGW_PACKAGE_PREFIX}-libffi"
       if: matrix.os == 'windows' && matrix.extconfopts == '--enable-system-libffi'
 
     - run: bundle install


### PR DESCRIPTION
This is because rubyinstaller-head switched to MINGW-UCRT, so the package prefix is
  mingw-w64-ucrt-x86_64
instead of
  mingw-w64-x86_64