### PR TITLE
Correct module lookup when including ffi-module

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -84,7 +84,7 @@ module FFI
     # @raise {RuntimeError} if +mod+ is not a Module
     # Test if extended object is a Module. If not, raise RuntimeError.
     def self.extended(mod)
-      raise RuntimeError.new("must only be extended by module") unless mod.kind_of?(Module)
+      raise RuntimeError.new("must only be extended by module") unless mod.kind_of?(::Module)
     end
 
 


### PR DESCRIPTION
The inclusion of @ioquatix's `ffi-module` gem to a project causes errors loading other ffi gems (such as `rbnacl`) due to the definition of `FFI::Module` which makes `.kind_of?(Module)` equivalent to `.kind_of?(FFI::Module)`.

This change simply changes that lookup to ensure that it is checking against the top-level Module constant.