### PR TITLE
fix unlink error 

### DIFF
--- a/lib/ffi/tools/const_generator.rb
+++ b/lib/ffi/tools/const_generator.rb
@@ -105,9 +105,10 @@ module FFI
     # @return [nil]
     # @raise if a constant is missing and +:required+ was set to +true+ (see {#initialize})
     def calculate(options = {})
-      binary = File.join Dir.tmpdir, "rb_const_gen_bin_#{Process.pid}"
+      binary_path = nil
 
       Tempfile.open("#{@prefix}.const_generator") do |f|
+        binary_path = f.path + ".bin"
         @includes.each do |inc|
           f.puts "#include <#{inc}>"
         end
@@ -125,7 +126,7 @@ module FFI
         f.flush
 
         cc = ENV['CC'] || 'gcc'
-        output = `#{cc} #{options[:cppflags]} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} 2>&1`
+        output = `#{cc} #{options[:cppflags]} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary_path} 2>&1`
 
         unless $?.success? then
           output = output.split("\n").map { |l| "\t#{l}" }.join "\n"
@@ -133,8 +134,8 @@ module FFI
         end
       end
 
-      output = `#{binary}`
-      File.unlink(binary + (FFI::Platform.windows? ? ".exe" : ""))
+      output = `#{binary_path}`
+      File.unlink(binary_path + (FFI::Platform.windows? ? ".exe" : ""))
       output.each_line do |line|
         line =~ /^(\S+)\s(.*)$/
         const = @constants[$1]


### PR DESCRIPTION
when using shared tmp dir inside parallel docker containers (same Process id)
you can see errors like below

```ruby
const_generator.rb:136:in ``': Text file busy - /tmp/rb_const_gen_bin_1 (Errno::ETXTBSY)
```

```ruby
const_generator.rb:137:in `unlink': No such file or directory @ apply2files - /tmp/rb_const_gen_bin_1 (Errno::ENOENT)
```