### PR TITLE
Move /opt before /usr to search for M1 native libs first - solve the conflicts when both x64 and arm64 libs installed

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -126,7 +126,7 @@ module FFI
               else
                 # TODO better library lookup logic
                 unless libname.start_with?("/") || FFI::Platform.windows?
-                  path = ['/usr/lib/','/usr/local/lib/','/opt/local/lib/', '/opt/homebrew/lib/'].find do |pth|
+                  path = ['/usr/lib/','/opt/local/lib/', '/opt/homebrew/lib/', '/usr/local/lib/'].find do |pth|
                     File.exist?(pth + libname)
                   end
                   if path


### PR DESCRIPTION
This is trying to solve 
https://github.com/ffi/ffi/issues/880#issuecomment-1019394749

In apple silicon machines, when both versions are installed, the native arm64 libs (`'/opt/local/lib/'`) should be the first option, and x64 (`'/usr/local/lib/'`) as a failsafe fallback only when arm64 version is not available.

In my case: I've installed both x64 & arm64 version of glib, but `ffi` found x64 and then stopped, giving up to try `/opt` ones
![image](https://user-images.githubusercontent.com/150648/150661350-03109bec-2780-4c36-832a-af39778c458e.png)

While placing `/opt` before `/usr/local`

![image](https://user-images.githubusercontent.com/150648/150661493-eb89ad61-9e5e-4def-9e1a-75fa47e087d0.png)
