### PR TITLE
move opt/homebrew/lib ahead of /usr/local/lib

### DIFF
--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -126,7 +126,7 @@ module FFI
               else
                 # TODO better library lookup logic
                 unless libname.start_with?("/") || FFI::Platform.windows?
-                  path = ['/usr/lib/','/usr/local/lib/','/opt/local/lib/', '/opt/homebrew/lib/'].find do |pth|
+                  path = ['/usr/lib/','/opt/homebrew/lib/', '/usr/local/lib/','/opt/local/lib/'].find do |pth|
                     File.exist?(pth + libname)
                   end
                   if path


### PR DESCRIPTION
This PR moves /opt/homebrew/lib ahead of /usr/local/lib in the library lookup directories ordering.

The reason is this:
/opt/homebrew/lib is the default path for homebrew on M1 macs
/usr/local/lib is the defualt path for homebrew on Intel Macs

For most users, this change won't do anything, because overwhelmingly only one of those folders will exist.

there is a small intersection of users who have both. the reason is often because they need both m1 and x86 versions of homebrew installed because of some dependency that is only available on x86 (i.e. openvino).

for those users, this would prefer the platform native m1 homebrew ahead of the x86 homebrew path.

so to summarize
intel macs can only have /usr/local/lib 
most m1 macs will only have /opt/homebrew/lib
a small number of m1 mac users will have both. this change affects them and it prefers the platform native path to the x86 path
