### PR TITLE
Bitmask improvement

### DIFF
--- a/lib/ffi/enum.rb
+++ b/lib/ffi/enum.rb
@@ -220,7 +220,7 @@ module FFI
     #  @param [Symbol] query
     #  @return [Integer]
     # @overload [](query)
-    #  Get bitmaks value from symbol array
+    #  Get bitmask value from symbol array
     #  @param [Array<Symbol>] query
     #  @return [Integer]
     # @overload [](*query)

--- a/lib/ffi/enum.rb
+++ b/lib/ffi/enum.rb
@@ -240,7 +240,7 @@ module FFI
       when Symbol
         flat_query.inject(0) do |val, o|
           v = @kv_map[o]
-          if v then val |= v else val end
+          if v then val | v else val end
         end
       when Integer, ->(o) { o.respond_to?(:to_int) }
         val = flat_query.inject(0) { |mask, o| mask |= o.to_int }
@@ -265,11 +265,11 @@ module FFI
         when Symbol
           v = @kv_map[o]
           raise ArgumentError, "invalid bitmask value, #{o.inspect}" unless v
-          val |= v
+          val | v
         when Integer
-          val |= o
+          val | o
         when ->(obj) { obj.respond_to?(:to_int) }
-          val |= o.to_int
+          val | o.to_int
         else
           raise ArgumentError, "invalid bitmask value, #{o.inspect}"
         end

--- a/lib/ffi/enum.rb
+++ b/lib/ffi/enum.rb
@@ -280,15 +280,13 @@ module FFI
     # @param ctx unused
     # @return [Array<Symbol, Integer>] list of symbol names corresponding to val, plus an optional remainder if some bits don't match any constant
     def from_native(val, ctx)
-      list = @kv_map.select { |_, v| v & val != 0 }.keys
+      flags = @kv_map.select { |_, v| v & val != 0 }
+      list = flags.keys
       # If there are unmatch flags,
       # return them in an integer,
       # else information can be lost.
       # Similar to Enum behavior.
-      remainder = val ^ list.inject(0) do |tmp, o|
-        v = @kv_map[o]
-        if v then tmp |= v else tmp end
-      end
+      remainder = val ^ flags.values.reduce(0, :|)
       list.push remainder unless remainder == 0
       return list
     end

--- a/spec/ffi/bitmask_spec.rb
+++ b/spec/ffi/bitmask_spec.rb
@@ -248,6 +248,23 @@ describe "A tagged typedef bitmask" do
     expect(TestBitmask4.test_tagged_nonint_bitmask6([1<<14,1<<42,1<<43])).to eq([:c26,:c28,1<<43])
   end
 
+  it "only remainder is given if only undefined mask are returned" do
+    expect(TestBitmask3.test_tagged_typedef_bitmask1(1<<4)).to eq([1<<4])
+    expect(TestBitmask3.test_tagged_typedef_bitmask1([1<<4])).to eq([1<<4])
+    expect(TestBitmask3.test_tagged_typedef_bitmask2(1<<6)).to eq([1<<6])
+    expect(TestBitmask3.test_tagged_typedef_bitmask2([1<<6])).to eq([1<<6])
+    expect(TestBitmask3.test_tagged_typedef_bitmask3(1<<7)).to eq([1<<7])
+    expect(TestBitmask3.test_tagged_typedef_bitmask3([1<<7])).to eq([1<<7])
+    expect(TestBitmask3.test_tagged_typedef_bitmask4(1<<9)).to eq([1<<9])
+    expect(TestBitmask3.test_tagged_typedef_bitmask4([1<<9])).to eq([1<<9])
+    expect(TestBitmask4.test_tagged_nonint_bitmask4(1<<10)).to eq([1<<10])
+    expect(TestBitmask4.test_tagged_nonint_bitmask4([1<<10])).to eq([1<<10])
+    expect(TestBitmask4.test_tagged_nonint_bitmask5(1<<16)).to eq([1<<16])
+    expect(TestBitmask4.test_tagged_nonint_bitmask5([1<<16])).to eq([1<<16])
+    expect(TestBitmask4.test_tagged_nonint_bitmask6(1<<43)).to eq([1<<43])
+    expect(TestBitmask4.test_tagged_nonint_bitmask6([1<<43])).to eq([1<<43])
+  end
+
   it "wrong constants rejected" do
     expect { TestBitmask3.test_tagged_typedef_bitmask1([:c2,:c4,:c5]) }.to raise_error(ArgumentError)
     expect { TestBitmask3.test_tagged_typedef_bitmask2([:c6,:c8,:c9]) }.to raise_error(ArgumentError)

--- a/spec/ffi/bitmask_spec.rb
+++ b/spec/ffi/bitmask_spec.rb
@@ -58,6 +58,40 @@ module TestBitmask4
   attach_function :test_tagged_nonint_bitmask6, :test_tagged_nonint_bitmask3,  [:bitmask_type6], :bitmask_type6
 end
 
+module TestBitmask5
+  extend FFI::Library
+  ffi_lib TestLibrary::PATH
+
+  bitmask FFI::Type::INT8, :bitmask_type1, [:c1, :c2, :c3, 7]
+  bitmask FFI::Type::INT16, :bitmask_type2, [:c4, :c5, :c6, 15]
+  bitmask FFI::Type::INT32, :bitmask_type3, [:c7, :c8, :c9, 31]
+  bitmask FFI::Type::INT64, :bitmask_type4, [:c10, :c11, :c12, 63]
+  bitmask FFI::Type::INT, :bitmask_type5, [:c13, :c14, :c15, FFI::Type::INT.size * 8 - 1]
+
+  attach_function :test_tagged_nonint_signed_bitmask1, [:bitmask_type1], :bitmask_type1
+  attach_function :test_tagged_nonint_signed_bitmask2, [:bitmask_type2], :bitmask_type2
+  attach_function :test_tagged_nonint_signed_bitmask3, [:bitmask_type3], :bitmask_type3
+  attach_function :test_tagged_nonint_signed_bitmask4, [:bitmask_type4], :bitmask_type4
+  attach_function :test_tagged_nonint_signed_bitmask5, :test_untagged_bitmask, [:bitmask_type5], :bitmask_type5
+end
+
+module TestBitmask6
+  extend FFI::Library
+  ffi_lib TestLibrary::PATH
+
+  bitmask FFI::Type::UINT8, :bitmask_type1, [:c1, :c2, :c3, 7]
+  bitmask FFI::Type::UINT16, :bitmask_type2, [:c4, :c5, :c6, 15]
+  bitmask FFI::Type::UINT32, :bitmask_type3, [:c7, :c8, :c9, 31]
+  bitmask FFI::Type::UINT64, :bitmask_type4, [:c10, :c11, :c12, 63]
+  bitmask FFI::Type::UINT, :bitmask_type5, [:c13, :c14, :c15, FFI::Type::UINT.size * 8 - 1]
+
+  attach_function :test_tagged_nonint_unsigned_bitmask1, :test_untagged_nonint_bitmask, [:bitmask_type1], :bitmask_type1
+  attach_function :test_tagged_nonint_unsigned_bitmask2, :test_tagged_nonint_bitmask1, [:bitmask_type2], :bitmask_type2
+  attach_function :test_tagged_nonint_unsigned_bitmask3, :test_tagged_nonint_bitmask2, [:bitmask_type3], :bitmask_type3
+  attach_function :test_tagged_nonint_unsigned_bitmask4, :test_tagged_nonint_bitmask3, [:bitmask_type4], :bitmask_type4
+  attach_function :test_tagged_nonint_unsigned_bitmask5, :test_tagged_uint_bitmask, [:bitmask_type5], :bitmask_type5
+end
+
 describe "A library with no bitmask or enum defined" do
   it "returns nil when asked for an enum" do
     expect(TestBitmask0.enum_type(:foo)).to be_nil
@@ -598,5 +632,25 @@ describe "All bitmasks" do
         bitmask FFI::Type::UINT64, [ :a, 2, :b, 5, :a, 0 ]
       end
     end.to raise_error(ArgumentError, /duplicate/)
+  end
+end
+
+describe "Signed bitmasks" do
+  it "do not return a remainder when used with their most significant bit set" do
+    expect(TestBitmask5.test_tagged_nonint_signed_bitmask1([:c1, :c2, :c3])).to eq([:c1, :c2, :c3])
+    expect(TestBitmask5.test_tagged_nonint_signed_bitmask2([:c4, :c5, :c6])).to eq([:c4, :c5, :c6])
+    expect(TestBitmask5.test_tagged_nonint_signed_bitmask3([:c7, :c8, :c9])).to eq([:c7, :c8, :c9])
+    expect(TestBitmask5.test_tagged_nonint_signed_bitmask4([:c10, :c11, :c12])).to eq([:c10, :c11, :c12])
+    expect(TestBitmask5.test_tagged_nonint_signed_bitmask5([:c13, :c14, :c15])).to eq([:c13, :c14, :c15])
+  end
+end
+
+describe "Unsigned bitmasks" do
+  it "do not return a remainder when used with their most significant bit set" do
+    expect(TestBitmask6.test_tagged_nonint_unsigned_bitmask1([:c1, :c2, :c3])).to eq([:c1, :c2, :c3])
+    expect(TestBitmask6.test_tagged_nonint_unsigned_bitmask2([:c4, :c5, :c6])).to eq([:c4, :c5, :c6])
+    expect(TestBitmask6.test_tagged_nonint_unsigned_bitmask3([:c7, :c8, :c9])).to eq([:c7, :c8, :c9])
+    expect(TestBitmask6.test_tagged_nonint_unsigned_bitmask4([:c10, :c11, :c12])).to eq([:c10, :c11, :c12])
+    expect(TestBitmask6.test_tagged_nonint_unsigned_bitmask5([:c13, :c14, :c15])).to eq([:c13, :c14, :c15])
   end
 end

--- a/spec/ffi/fixtures/BitmaskTest.c
+++ b/spec/ffi/fixtures/BitmaskTest.c
@@ -29,6 +29,26 @@ uint64_t test_tagged_nonint_bitmask3(uint64_t val) {
     return val;
 }
 
+unsigned int test_tagged_uint_bitmask(unsigned int val) {
+    return val;
+}
+
+int8_t test_tagged_nonint_signed_bitmask1(int8_t val) {
+    return val;
+}
+
+int16_t test_tagged_nonint_signed_bitmask2(int16_t val) {
+    return val;
+}
+
+int32_t test_tagged_nonint_signed_bitmask3(int32_t val) {
+    return val;
+}
+
+int64_t test_tagged_nonint_signed_bitmask4(int64_t val) {
+    return val;
+}
+
 typedef enum {c1 = (1<<0), c2 = (1<<1), c3 = (1<<2), c4 = (1<<3)} bitmask_type1;
 int test_tagged_typedef_bitmask1(int val) {
     return val;


### PR DESCRIPTION
Hello,

I encountered an issue with the current Bitmask implementation (I wrote those, so I am to blame), when the native type is signed, and a flag uses the most significant bit. The fact that the native value can be negative was causing some incorrect remainders when decoding the flags, and range errors when synthesizing the value from the flags.

This PR fixes the above issue, and adds relevant tests.
One of those tests fails on TruffleRuby: testing UINT64 bitmasks with most significant bit set:
`unsupported type [9223372036854775811]` which corresponds to `0x8000000000000003 == (1<<63) | (1<<1) | (1<<0)`
I assume this is a limitation of TruffleRuby, but wanted to check before adding this to the expected failure list.

I've also taken the opportunity to clean the code up a bit.

Thanks,
Brice