### PR TITLE
Normalize pointer typedef names

### DIFF
--- a/lib/ffi/platform/aarch64-freebsd12/types.conf
+++ b/lib/ffi/platform/aarch64-freebsd12/types.conf
@@ -1,4 +1,3 @@
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.___wchar_t = uint
 rbx.platform.typedef.__accmode_t = int
 rbx.platform.typedef.__blkcnt_t = long

--- a/lib/ffi/platform/aarch64-linux/types.conf
+++ b/lib/ffi/platform/aarch64-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = int

--- a/lib/ffi/platform/arm-freebsd/types.conf
+++ b/lib/ffi/platform/arm-freebsd/types.conf
@@ -1,5 +1,3 @@
-
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.__accmode_t = int
 rbx.platform.typedef.__blkcnt_t = long_long
 rbx.platform.typedef.__blksize_t = uint

--- a/lib/ffi/platform/arm-freebsd12/types.conf
+++ b/lib/ffi/platform/arm-freebsd12/types.conf
@@ -1,5 +1,3 @@
-
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.__accmode_t = int
 rbx.platform.typedef.__blkcnt_t = long_long
 rbx.platform.typedef.__blksize_t = uint

--- a/lib/ffi/platform/arm-linux/types.conf
+++ b/lib/ffi/platform/arm-linux/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*__caddr_t = char
+rbx.platform.typedef.__caddr_t = char
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/i386-freebsd/types.conf
+++ b/lib/ffi/platform/i386-freebsd/types.conf
@@ -1,5 +1,3 @@
-
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.__accmode_t = int
 rbx.platform.typedef.__blkcnt_t = long_long
 rbx.platform.typedef.__blksize_t = uint

--- a/lib/ffi/platform/i386-freebsd12/types.conf
+++ b/lib/ffi/platform/i386-freebsd12/types.conf
@@ -1,5 +1,3 @@
-
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.__accmode_t = int
 rbx.platform.typedef.__blkcnt_t = long_long
 rbx.platform.typedef.__blksize_t = uint

--- a/lib/ffi/platform/i386-gnu/types.conf
+++ b/lib/ffi/platform/i386-gnu/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/i386-linux/types.conf
+++ b/lib/ffi/platform/i386-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/i386-solaris/types.conf
+++ b/lib/ffi/platform/i386-solaris/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*caddr_t = char
+rbx.platform.typedef.caddr_t = char
 rbx.platform.typedef.blkcnt64_t = long_long
 rbx.platform.typedef.blkcnt_t = long_long
 rbx.platform.typedef.blksize_t = long

--- a/lib/ffi/platform/ia64-linux/types.conf
+++ b/lib/ffi/platform/ia64-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/loongarch64-linux/types.conf
+++ b/lib/ffi/platform/loongarch64-linux/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*__caddr_t = char
+rbx.platform.typedef.__caddr_t = char
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = int

--- a/lib/ffi/platform/mips-linux/types.conf
+++ b/lib/ffi/platform/mips-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mips64-linux/types.conf
+++ b/lib/ffi/platform/mips64-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mips64el-linux/types.conf
+++ b/lib/ffi/platform/mips64el-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mipsel-linux/types.conf
+++ b/lib/ffi/platform/mipsel-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mipsisa32r6-linux/types.conf
+++ b/lib/ffi/platform/mipsisa32r6-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mipsisa32r6el-linux/types.conf
+++ b/lib/ffi/platform/mipsisa32r6el-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mipsisa64r6-linux/types.conf
+++ b/lib/ffi/platform/mipsisa64r6-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/mipsisa64r6el-linux/types.conf
+++ b/lib/ffi/platform/mipsisa64r6el-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/powerpc-linux/types.conf
+++ b/lib/ffi/platform/powerpc-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/powerpc64-linux/types.conf
+++ b/lib/ffi/platform/powerpc64-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/powerpc64le-linux/types.conf
+++ b/lib/ffi/platform/powerpc64le-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/riscv64-linux/types.conf
+++ b/lib/ffi/platform/riscv64-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = int

--- a/lib/ffi/platform/s390-linux/types.conf
+++ b/lib/ffi/platform/s390-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/s390x-linux/types.conf
+++ b/lib/ffi/platform/s390x-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/sparc-linux/types.conf
+++ b/lib/ffi/platform/sparc-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long_long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long_long
 rbx.platform.typedef.__blkcnt64_t = long_long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/sparc-solaris/types.conf
+++ b/lib/ffi/platform/sparc-solaris/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*caddr_t = char
+rbx.platform.typedef.caddr_t = char
 rbx.platform.typedef.Psocklen_t = pointer
 rbx.platform.typedef.avl_index_t = uint
 rbx.platform.typedef.blkcnt64_t = long_long

--- a/lib/ffi/platform/sparc-solaris/types.conf
+++ b/lib/ffi/platform/sparc-solaris/types.conf
@@ -1,4 +1,3 @@
-rbx.platform.typedef.() = pointer
 rbx.platform.typedef.*caddr_t = char
 rbx.platform.typedef.Psocklen_t = pointer
 rbx.platform.typedef.avl_index_t = uint

--- a/lib/ffi/platform/sparc64-linux/types.conf
+++ b/lib/ffi/platform/sparc64-linux/types.conf
@@ -1,5 +1,5 @@
-rbx.platform.typedef.*__caddr_t = char
-rbx.platform.typedef.*__qaddr_t = long
+rbx.platform.typedef.__caddr_t = char
+rbx.platform.typedef.__qaddr_t = long
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/sparcv9-solaris/types.conf
+++ b/lib/ffi/platform/sparcv9-solaris/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*caddr_t = char
+rbx.platform.typedef.caddr_t = char
 rbx.platform.typedef.Psocklen_t = pointer
 rbx.platform.typedef.avl_index_t = uint
 rbx.platform.typedef.blkcnt64_t = long_long

--- a/lib/ffi/platform/sparcv9-solaris/types.conf
+++ b/lib/ffi/platform/sparcv9-solaris/types.conf
@@ -1,4 +1,3 @@
-rbx.platform.typedef.() = pointer
 rbx.platform.typedef.*caddr_t = char
 rbx.platform.typedef.Psocklen_t = pointer
 rbx.platform.typedef.avl_index_t = uint

--- a/lib/ffi/platform/x86_64-dragonflybsd/types.conf
+++ b/lib/ffi/platform/x86_64-dragonflybsd/types.conf
@@ -1,4 +1,3 @@
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.___wchar_t = int
 rbx.platform.typedef.__clock_t = ulong
 rbx.platform.typedef.__clockid_t = ulong

--- a/lib/ffi/platform/x86_64-freebsd12/types.conf
+++ b/lib/ffi/platform/x86_64-freebsd12/types.conf
@@ -1,4 +1,3 @@
-rbx.platform.typedef.*) = pointer
 rbx.platform.typedef.___wchar_t = int
 rbx.platform.typedef.__accmode_t = int
 rbx.platform.typedef.__blkcnt_t = long

--- a/lib/ffi/platform/x86_64-haiku/types.conf
+++ b/lib/ffi/platform/x86_64-haiku/types.conf
@@ -113,5 +113,4 @@ rbx.platform.typedef.unchar = uchar
 rbx.platform.typedef.unichar = ushort
 rbx.platform.typedef.useconds_t = uint
 rbx.platform.typedef.ushort = ushort
-rbx.platform.typedef.void*) = pointer
 rbx.platform.typedef.wchar_t = int

--- a/lib/ffi/platform/x86_64-linux/types.conf
+++ b/lib/ffi/platform/x86_64-linux/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*__caddr_t = char
+rbx.platform.typedef.__caddr_t = char
 rbx.platform.typedef.__blkcnt64_t = long
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = long

--- a/lib/ffi/platform/x86_64-msys/types.conf
+++ b/lib/ffi/platform/x86_64-msys/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*addr_t = char
+rbx.platform.typedef.addr_t = char
 rbx.platform.typedef.__ULong = uint
 rbx.platform.typedef.__blkcnt_t = long
 rbx.platform.typedef.__blksize_t = int

--- a/lib/ffi/platform/x86_64-solaris/types.conf
+++ b/lib/ffi/platform/x86_64-solaris/types.conf
@@ -1,4 +1,4 @@
-rbx.platform.typedef.*caddr_t = char
+rbx.platform.typedef.caddr_t = char
 rbx.platform.typedef.blkcnt64_t = long
 rbx.platform.typedef.blkcnt_t = long
 rbx.platform.typedef.blksize_t = int


### PR DESCRIPTION
Building on PR #953, I also removed the leading `*` character from all typedef names. This normalizes the typedef names for pointer types, such as `caddr_t`. So instead of having `:"*caddr"` on some platforms, we only have `:caddr` across all platforms.