### PR TITLE
Fix Pointer#initialize using NUM2LL instead of NUM2ULL

### DIFF
--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -112,7 +112,7 @@ ptr_initialize(int argc, VALUE* argv, VALUE self)
     switch (TYPE(rbAddress)) {
         case T_FIXNUM:
         case T_BIGNUM:
-            p->memory.address = (void*) (uintptr_t) NUM2LL(rbAddress);
+            p->memory.address = (void*) (uintptr_t) NUM2ULL(rbAddress);
             p->memory.size = LONG_MAX;
             if (p->memory.address == NULL) {
                 p->memory.flags = 0;

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -244,7 +244,7 @@ describe "Pointer" do
       pointer = FFI::Pointer.new(:uint8, max_address)
       expect(pointer.address).to eq(max_address)
     end
-  end if RUBY_ENGINE != "truffleruby"
+  end if (RUBY_ENGINE != "truffleruby" && RUBY_ENGINE != "jruby")
 end
 
 describe "AutoPointer" do

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -244,7 +244,7 @@ describe "Pointer" do
       pointer = FFI::Pointer.new(:uint8, max_address)
       expect(pointer.address).to eq(max_address)
     end
-  end
+  end if RUBY_ENGINE != "truffleruby"
 end
 
 describe "AutoPointer" do

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -237,6 +237,14 @@ describe "Pointer" do
       expect(FFI::Pointer.new(0).slice(0, 10).size_limit?).to be true
     end
   end
+
+  describe "#initialise" do
+    it 'can use adresses with high bit set' do
+      max_address = 2**FFI::Platform::ADDRESS_SIZE - 1
+      pointer = FFI::Pointer.new(:uint8, max_address)
+      expect(pointer.address).to eq(max_address)
+    end
+  end
 end
 
 describe "AutoPointer" do


### PR DESCRIPTION
If the high bit of the address was set this would raise RangeError (bignum too big to convert into long long). This is not uncommon on platforms that use the high bits of pointers for purposes such as pointer authentication (eg arm64 on apple platforms - https://developer.apple.com/documentation/security/preparing_your_app_to_work_with_pointer_authentication )

I've not encountered this error directily but I have had reports of it from users with apple M1 hardware

This also now matches Pointer#address which uses ULL2NUM.
