### PR TITLE
Tapioca DSL Compiler

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -460,6 +460,16 @@ function_release(VALUE self)
     return self;
 }
 
+static VALUE
+function_type(VALUE self)
+{
+    Function* fn;
+
+    Data_Get_Struct(self, Function, fn);
+
+    return fn->rbFunctionInfo;
+}
+
 static void
 callback_invoke(ffi_cif* cif, void* retval, void** parameters, void* user_data)
 {
@@ -890,6 +900,7 @@ rbffi_Function_Init(VALUE moduleFFI)
     rb_define_method(rbffi_FunctionClass, "call", function_call, -1);
     rb_define_method(rbffi_FunctionClass, "attach", function_attach, 2);
     rb_define_method(rbffi_FunctionClass, "free", function_release, 0);
+    rb_define_method(rbffi_FunctionClass, "type", function_type, 0);
     rb_define_method(rbffi_FunctionClass, "autorelease=", function_set_autorelease, 1);
     /*
      * call-seq: autorelease

--- a/ext/ffi_c/MappedType.c
+++ b/ext/ffi_c/MappedType.c
@@ -144,6 +144,16 @@ mapped_from_native(int argc, VALUE* argv, VALUE self)
     return rb_funcall2(m->rbConverter, id_from_native, argc, argv);
 }
 
+static VALUE
+mapped_converter(VALUE self)
+{
+    MappedType*m = NULL;
+
+    Data_Get_Struct(self, MappedType, m);
+
+    return m->rbConverter;
+}
+
 void
 rbffi_MappedType_Init(VALUE moduleFFI)
 {
@@ -164,5 +174,6 @@ rbffi_MappedType_Init(VALUE moduleFFI)
     rb_define_method(rbffi_MappedTypeClass, "native_type", mapped_native_type, 0);
     rb_define_method(rbffi_MappedTypeClass, "to_native", mapped_to_native, -1);
     rb_define_method(rbffi_MappedTypeClass, "from_native", mapped_from_native, -1);
+    rb_define_method(rbffi_MappedTypeClass, "converter", mapped_converter, 0);
 }
 

--- a/ext/ffi_c/Variadic.c
+++ b/ext/ffi_c/Variadic.c
@@ -157,6 +157,15 @@ variadic_initialize(VALUE self, VALUE rbFunction, VALUE rbParameterTypes, VALUE 
 }
 
 static VALUE
+variadic_return_type(VALUE self)
+{
+    VariadicInvoker* invoker;
+
+    Data_Get_Struct(self, VariadicInvoker, invoker);
+    return invoker->rbReturnType;
+}
+
+static VALUE
 variadic_invoke(VALUE self, VALUE parameterTypes, VALUE parameterValues)
 {
     VariadicInvoker* invoker;
@@ -299,5 +308,6 @@ rbffi_Variadic_Init(VALUE moduleFFI)
 
     rb_define_method(classVariadicInvoker, "initialize", variadic_initialize, 4);
     rb_define_method(classVariadicInvoker, "invoke", variadic_invoke, 2);
+    rb_define_method(classVariadicInvoker, "return_type", variadic_return_type, 0);
 }
 

--- a/ext/ffi_c/Variadic.c
+++ b/ext/ffi_c/Variadic.c
@@ -157,7 +157,7 @@ variadic_initialize(VALUE self, VALUE rbFunction, VALUE rbParameterTypes, VALUE 
 }
 
 static VALUE
-variadic_return_type(VALUE self)
+variadic_result_type(VALUE self)
 {
     VariadicInvoker* invoker;
 
@@ -308,6 +308,5 @@ rbffi_Variadic_Init(VALUE moduleFFI)
 
     rb_define_method(classVariadicInvoker, "initialize", variadic_initialize, 4);
     rb_define_method(classVariadicInvoker, "invoke", variadic_invoke, 2);
-    rb_define_method(classVariadicInvoker, "return_type", variadic_return_type, 0);
+    rb_define_method(classVariadicInvoker, "result_type", variadic_result_type, 0);
 }
-

--- a/lib/ffi/variadic.rb
+++ b/lib/ffi/variadic.rb
@@ -62,8 +62,13 @@ module FFI
       def #{mname}(#{params})
         @@#{mname}.#{call}(#{params})
       end
+      @@ffi_functions[:#{mname}] = [invoker.fixed_param_types + [:varargs], invoker.result_type]
       code
       invoker
+    end
+
+    def fixed_param_types
+      @fixed
     end
   end
 end

--- a/lib/tapioca/dsl/compilers/ffi.rb
+++ b/lib/tapioca/dsl/compilers/ffi.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+begin
+  require "ffi"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::FFI` generate types for functions and
+      # variables bound by Ruby-FFI for dynamically-linked native libraries.
+      # Ruby-FFI dynamically defines constants and methods at runtime. For
+      # example, given a module:
+      #
+      #   module MyModule
+      #     extend FFI::Library
+      #     ffi_lib 'mylib'
+      #
+      #     attach_function :func, [:int, :pointer], :void
+      #     attach_variable :var, :string
+      #   end
+      #
+      # This will result in the following methods being defined:
+      #
+      #   func, var, var=
+      #
+      class FFI < Compiler
+        def decorate
+          root.create_path(constant) do |mod|
+            constant.class_variables.each do |class_var|
+              candidate = constant.class_variable_get(class_var)
+              if candidate.is_a?(::FFI::Function)
+                method_name = class_var.to_s.gsub(/\A@*/, "")
+                if candidate.respond_to?(:type)
+                  mod.create_method(
+                    method_name,
+                    parameters: params_for(candidate.type.param_types),
+                    return_type: return_type_for(candidate.type.result_type),
+                    class_method: true,
+                  )
+                else
+                  mod.create_method(
+                    method_name,
+                    parameters: [create_rest_param("args", type: "T.untyped")],
+                    return_type: "T.untyped",
+                    class_method: true,
+                  )
+                end
+              elsif candidate.is_a?(::FFI::VariadicInvoker)
+                param_types =
+                  params_for(candidate.instance_variable_get(:@fixed)) + [create_rest_param("rest", type: "T.untyped")]
+                mod.create_method(
+                  class_var.to_s.gsub(/\A@*/, ""),
+                  parameters: param_types,
+                  return_type: (
+                    if candidate.respond_to?(:return_type)
+                      return_type_for(candidate.return_type)
+                    else
+                      "T.untyped"
+                    end
+                  ),
+                  class_method: true,
+                )
+              elsif candidate.is_a?(::FFI::Struct) && class_var =~ /\A@@ffi_gvar_(.+)\z/
+                getter = T.must(::Regexp.last_match(1))
+                return_type = return_type_for(candidate.layout.fields[0].type)
+                mod.create_method(
+                  getter,
+                  parameters: [],
+                  return_type: return_type,
+                  class_method: true,
+                )
+                setter = "#{getter}="
+                if constant.respond_to?(setter)
+                  mod.create_method(
+                    setter,
+                    parameters: [
+                      create_param("value", type: type_for(candidate.layout.fields[0].type)),
+                    ],
+                    return_type: return_type,
+                    class_method: true,
+                  )
+                end
+              end
+            end
+          end
+        end
+
+        private
+
+        MAPPING = T.let({
+          ::FFI::Type::BOOL => "T::Boolean",
+          ::FFI::Type::BUFFER_IN => "::FFI::Pointer",
+          ::FFI::Type::BUFFER_INOUT => "::FFI::Pointer",
+          ::FFI::Type::BUFFER_OUT => "::FFI::Pointer",
+          ::FFI::Type::CHAR => "Integer",
+          ::FFI::Type::DOUBLE => "Float",
+          ::FFI::Type::FLOAT => "Float",
+          ::FFI::Type::FLOAT32 => "Float",
+          ::FFI::Type::FLOAT64 => "Float",
+          ::FFI::Type::INT => "Integer",
+          ::FFI::Type::INT16 => "Integer",
+          ::FFI::Type::INT32 => "Integer",
+          ::FFI::Type::INT64 => "Integer",
+          ::FFI::Type::INT8 => "Integer",
+          ::FFI::Type::LONG => "Integer",
+          ::FFI::Type::LONGDOUBLE => "Float",
+          ::FFI::Type::LONG_LONG => "Integer",
+          ::FFI::Type::POINTER => "::FFI::Pointer",
+          ::FFI::Type::SCHAR => "Integer",
+          ::FFI::Type::SHORT => "Integer",
+          ::FFI::Type::SINT => "Integer",
+          ::FFI::Type::SLONG => "Integer",
+          ::FFI::Type::SLONG_LONG => "Integer",
+          ::FFI::Type::SSHORT => "Integer",
+          ::FFI::Type::STRING => "String",
+          ::FFI::Type::UCHAR => "Integer",
+          ::FFI::Type::UINT => "Integer",
+          ::FFI::Type::UINT16 => "Integer",
+          ::FFI::Type::UINT32 => "Integer",
+          ::FFI::Type::UINT64 => "Integer",
+          ::FFI::Type::UINT8 => "Integer",
+          ::FFI::Type::ULONG => "Integer",
+          ::FFI::Type::ULONG_LONG => "Integer",
+          ::FFI::Type::USHORT => "Integer",
+          ::FFI::Type::VOID => "void",
+        }, T::Hash[::FFI::Type, String])
+
+        def return_type_for(ffi_type)
+          type_for(ffi_type, for_return: true)
+        end
+
+        def type_for(ffi_type, for_return: false)
+          if ffi_type == ::FFI::Type::POINTER && !for_return
+            # Special case, pointers as params can be one of several
+            "T.nilable(T.any(::FFI::Pointer, String, Integer))"
+          elsif ffi_type.is_a?(::FFI::Type::Mapped)
+            mapped_type_for(ffi_type)
+          elsif ffi_type.is_a?(::FFI::StructByValue)
+            ffi_type.struct_class.class_name
+          elsif ffi_type.is_a?(::FFI::Type::Array)
+            "[#{Array.new(ffi_type.length, type_for(ffi_type.elem_type)).join(", ")}]"
+          elsif ffi_type.is_a?(::FFI::Type::Function)
+            params = ffi_type.param_types.map { |param_type| type_for(param_type).to_s }.join(", ")
+            result = (
+              if ffi_type.result_type == ::FFI::Type::VOID
+                "void"
+              else
+                "returns(#{return_type_for(ffi_type.result_type)})"
+              end
+            )
+            "T.proc.params(#{params}).#{result}"
+          else
+            MAPPING.fetch(ffi_type, "T::Untyped")
+          end
+        end
+
+        def mapped_type_for(ffi_type)
+          return "T::Untyped" unless ffi_type.respond_to?(:converter)
+
+          converter = ffi_type.converter
+
+          if converter.is_a?(::FFI::StructByReference)
+            converter.struct_class.class_name
+          elsif converter == ::FFI::StrPtrConverter
+            "[String, ::FFI::Pointer]"
+          else
+            "T::Untyped"
+          end
+        end
+
+        def params_for(ffi_types)
+          ffi_types.map.with_index do |ffi_type, index|
+            create_param("arg#{index}", type: type_for(ffi_type))
+          end
+        end
+
+        class << self
+          def gather_constants
+            # Find all Modules that are:
+            all_modules.select do |mod|
+              # named (i.e. not anonymous)
+              name_of(mod) &&
+                # not singleton classes
+                !mod.singleton_class? &&
+                # extend ActiveSupport::Concern, and
+                mod.singleton_class < ::FFI::Library
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -53,7 +53,9 @@ describe FFI::Function do
   end
 
   it 'can be attached to a module' do
-    module Foo; end
+    module Foo
+      class_variable_set(:@@ffi_functions, {})
+    end
     fp = FFI::Function.new(:int, [:int, :int], @libtest.find_function('testAdd'))
     fp.attach(Foo, 'add')
     expect(Foo.add(10, 10)).to eq(20)
@@ -63,6 +65,7 @@ describe FFI::Function do
     fp = FFI::Function.new(:int, [:int, :int], @libtest.find_function('testAdd'))
     foo = Object.new
     class << foo
+      class_variable_set(:@@ffi_functions, {})
       def singleton_class
         class << self; self; end
       end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -198,9 +198,11 @@ describe "Library" do
       mod = Module.new do |m|
         m.extend FFI::Library
         ffi_lib File.expand_path(TestLibrary::PATH)
-        attach_function :bool_return_true, [ ], :bool
+        attach_function :bool_return_true, [ :string ], :bool
       end
-      expect(mod.class_variable_get(:@@bool_return_true).type.result_type).to eq FFI::Type::BOOL
+      expect(mod.attached_functions).to eq(
+        { bool_return_true: [[FFI::Type::STRING], FFI::Type::BOOL] }
+      )
     end
   end
 
@@ -329,6 +331,8 @@ describe "Library" do
       lib.gvar[:data] = i
       val = GlobalStruct.new(lib.get)
       expect(val[:data]).to eq(i)
+
+      expect(lib.attached_getters).to eq({ gvar: GlobalStruct })
     end
   end
 end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -193,6 +193,15 @@ describe "Library" do
       end
       expect(mod.bool_return_true).to be true
     end
+
+    it "can reveal the function type" do
+      mod = Module.new do |m|
+        m.extend FFI::Library
+        ffi_lib File.expand_path(TestLibrary::PATH)
+        attach_function :bool_return_true, [ ], :bool
+      end
+      expect(mod.class_variable_get(:@@bool_return_true).type.result_type).to eq FFI::Type::BOOL
+    end
   end
 
   def gvar_lib(name, type)

--- a/spec/ffi/struct_by_ref_spec.rb
+++ b/spec/ffi/struct_by_ref_spec.rb
@@ -41,7 +41,7 @@ describe FFI::Struct, ' by_ref' do
   end
 
   it "can reveal the mapped type converter" do
-    param_type = @api.class_variable_get(:@@struct_test).type.param_types[0]
+    param_type = @api.attached_functions[:struct_test][0][0]
     expect(param_type.converter).to be_a(FFI::StructByReference)
   end
 end

--- a/spec/ffi/struct_by_ref_spec.rb
+++ b/spec/ffi/struct_by_ref_spec.rb
@@ -39,5 +39,9 @@ describe FFI::Struct, ' by_ref' do
 
     expect { @api.struct_test(other_class.new) }.to raise_error(TypeError)
   end
-end
 
+  it "can reveal the mapped type converter" do
+    param_type = @api.class_variable_get(:@@struct_test).type.param_types[0]
+    expect(param_type.converter).to be_a(FFI::StructByReference)
+  end
+end

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -37,6 +37,10 @@ describe "Function with variadic arguments" do
     expect(LibTest.pack_varargs2(buf, :c1, "ii", :int, :c3, :int, :c4)).to eq(:c2)
   end
 
+  it "can reveal its return" do
+    expect(LibTest.class_variable_get(:@@testBlockingRWva).return_type).to eq(FFI::Type::CHAR)
+  end
+
   it 'can wrap a blocking function with varargs' do
     handle = LibTest.testBlockingOpen
     expect(handle).not_to be_null

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -38,7 +38,7 @@ describe "Function with variadic arguments" do
   end
 
   it "can reveal its return" do
-    expect(LibTest.class_variable_get(:@@testBlockingRWva).return_type).to eq(FFI::Type::CHAR)
+    expect(LibTest.attached_functions[:testBlockingWRva]).to eq([[FFI::Type::POINTER, FFI::Type::CHAR, :varargs], FFI::Type::INT8])
   end
 
   it 'can wrap a blocking function with varargs' do


### PR DESCRIPTION
This adds a [Tapioca](https://github.com/Shopify/tapioca) DSL compiler for FFI declarations, to generate [RBI files](https://sorbet.org/docs/rbi) with type information for Sorbet.

The first commit exposes some information that the compiler needs to be able to generate types. Without this information the types would be a lot less precise. The second commit adds the compiler itself.

The compiler is picked up automatically by Tapioca when this gem is installed in the project in which Tapioca is run.

I had originally planned to open a PR for only the first commit here and contribute the compiler to the Tapioca repo, but it occurred to me that here is a better place for it. One advantage of having it here is that it prevents people from using the compiler with an older FFI version, which would generate disappointing types.

I have a full test suite for the compiler sitting here but it was written for the Tapioca test harness, I'll have to adapt it to rspec. Before I do that, is there any interest in this at all? And if not, would you accept a PR with just the first commit?
