### PR TITLE
Add error message of newer Macos to linker script emulation

### DIFF
--- a/lib/ffi/dynamic_library.rb
+++ b/lib/ffi/dynamic_library.rb
@@ -74,7 +74,7 @@ module FFI
 
       # LoadError for C ext & JRuby, RuntimeError for TruffleRuby
       rescue LoadError, RuntimeError => ex
-        if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short|invalid file format)/
+        if ex.message =~ /(([^ \t()'])+\.so([^ \t:()'])*)[:']([ \t\(])*(invalid ELF header|file too short|invalid file format|not a mach-o file)/
           if File.binread($1) =~ /(?:GROUP|INPUT) *\( *([^ \)]+)/
             return try_load($1, flags, errors)
           end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -88,7 +88,7 @@ describe "Library" do
       }.to raise_error(LoadError)
     end
 
-    it "interprets INPUT() in loader scripts", unless: FFI::Platform.windows? do
+    it "interprets INPUT() in linker scripts", unless: FFI::Platform.windows? do
       path = File.dirname(TestLibrary::PATH)
       file = File.basename(TestLibrary::PATH)
       script = File.join(path, "ldscript.so")


### PR DESCRIPTION
.. and adjust the regex to match the new format of the message text.
The new error message is raised in macOS-12.6.1 while macOS-11.7 worked.

Fixes https://github.com/ffi/ffi/issues/981