### PR TITLE
Skip spec of linker script emulation on Macos

### DIFF
--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -88,7 +88,7 @@ describe "Library" do
       }.to raise_error(LoadError)
     end
 
-    it "interprets INPUT() in loader scripts", unless: FFI::Platform.windows? do
+    it "interprets INPUT() in linker scripts", unless: FFI::Platform.windows? || FFI::Platform.mac? do
       path = File.dirname(TestLibrary::PATH)
       file = File.basename(TestLibrary::PATH)
       script = File.join(path, "ldscript.so")


### PR DESCRIPTION
It fails in Macos-12, since that version raises a different error message than Macos-11. On the other hand, linker script emulation seems not to be in use on Macos at all, since Macos uses .dylib file extansion rather than .so.

Fixes #981