### PR TITLE
Upgrade rake-compiler for Ruby 3.2 prebuilt binaries

### DIFF
--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.require_paths << 'ext/ffi_c'
   s.required_ruby_version = '>= 2.3'
   s.add_development_dependency 'rake', '~> 13.0'
-  s.add_development_dependency 'rake-compiler', '~> 1.1'
-  s.add_development_dependency 'rake-compiler-dock', '~> 1.0'
+  s.add_development_dependency 'rake-compiler', '~> 1.2'
+  s.add_development_dependency 'rake-compiler-dock', '~> 1.3'
   s.add_development_dependency 'rspec', '~> 2.14.1'
 end


### PR DESCRIPTION
Please release binaries which support Ruby 3.2 after merging this. It seems in particular `x64-mingw-ucrt` is not being supported for Ruby 3.2 (it works on Ruby 3.1)