### PR TITLE
More platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,162 @@ jobs:
       if: ${{ matrix.ruby != 'truffleruby-head' && matrix.ruby != 'jruby-head' }}
       env:
         ITER: 10
+
+  rcd_build:
+    name: build fat binary gems
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86-mingw32
+          - x64-mingw-ucrt
+          - x64-mingw32
+          - x86-linux-gnu
+          - x86-linux-musl
+          - x86_64-linux-gnu
+          - x86_64-linux-musl
+          - x86_64-darwin
+          - arm64-darwin
+          - arm-linux-gnu
+          - arm-linux-musl
+          - aarch64-linux-gnu
+          - aarch64-linux-musl
+
+    runs-on: ubuntu-latest
+    env:
+      PLATFORM: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+
+      - name: Build ffi.gem
+        run: |
+          bundle install
+          bundle exec rake libffi
+          bundle exec rake gem:${PLATFORM}
+
+      - name: Upload binary gem
+        uses: actions/upload-artifact@v4
+        with:
+          name: gem-${{ matrix.platform }}
+          path: pkg/*-*-*.gem
+
+  job_test_native:
+    name: native test
+    needs: rcd_build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows
+          - macos
+          - ubuntu
+        ruby:
+          - "3.3"
+          - "3.2"
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - "2.5"
+        include:
+          - os: windows
+            platform: x64-mingw32
+          - os: macos
+            platform: x86_64-darwin
+          - os: ubuntu
+            platform: x86_64-linux-gnu
+          - os: windows
+            ruby: "3.1"
+            platform: x64-mingw-ucrt
+          - os: windows
+            ruby: "3.2"
+            platform: x64-mingw-ucrt
+          - os: windows
+            ruby: "3.3"
+            platform: x64-mingw-ucrt
+        exclude:
+          - os: windows
+            ruby: "3.1"
+          - os: windows
+            ruby: "3.2"
+          - os: windows
+            ruby: "3.3"
+
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: ruby --version
+      - name: Download gem-${{matrix.platform}}
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-${{ matrix.platform }}
+      - name: Update rubygems - ruby-3.0
+        if: matrix.ruby == '3.0'
+        run: |
+          gem install --no-doc rubygems-update -v 3.5.7
+          update_rubygems
+      - name: Update rubygems - ruby-2.6 to 2.7
+        if: matrix.ruby == '2.6' || matrix.ruby == '2.7'
+        run: |
+          gem install --no-doc rubygems-update -v 3.4.22
+          update_rubygems
+      - name: Update rubygems - ruby-2.5
+        if: matrix.ruby == '2.5'
+        run: |
+          gem install --no-doc rubygems-update -v 3.3.27
+          update_rubygems
+      - name: Install gem-${{matrix.platform}}
+        run: gem install --local *.gem --verbose
+      - name: Run tests
+        run: |
+          bundle install
+          ruby -rffi -S rake test
+
+  job_fat_binary_multiarch:
+    name: multiarch (${{matrix.platform}} on ${{matrix.from_image}} ${{matrix.image_platform}})
+    needs: rcd_build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - from_image: centos
+            image_platform: linux/x86_64
+            gem_platform: x86_64-linux-gnu
+            dockerfile: centos
+          - from_image: navikey/raspbian-bullseye
+            image_platform: linux/arm
+            gem_platform: arm-linux-gnu
+            dockerfile: debian
+          - from_image: ubuntu
+            image_platform: linux/arm64/v8
+            gem_platform: aarch64-linux-gnu
+            dockerfile: debian
+          - from_image: alpine
+            image_platform: linux/386
+            gem_platform: x86-linux-musl
+            dockerfile: alpine
+          - from_image: alpine
+            image_platform: linux/arm/v6
+            gem_platform: arm-linux-musl
+            dockerfile: alpine
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download gem-${{matrix.gem_platform}}
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-${{ matrix.gem_platform }}
+      - name: Build image and Run tests
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker build --rm --platform ${{matrix.image_platform}} --build-arg from_image=${{matrix.from_image}} -t ruby-test -f spec/env/Dockerfile.${{matrix.dockerfile}} .
+          docker run --rm -t --network=host -v `pwd`:/build ruby-test

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'bigdecimal'
+  gem 'bigdecimal' unless RUBY_VERSION =~ /^2\.[4567]|^3\.[012]\./ # necessary on ruby-3.3+
   gem 'bundler', '>= 1.16', '< 3'
   gem 'rake', '~> 13.0'
   gem 'rake-compiler', '~> 1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development do
   gem 'bundler', '>= 1.16', '< 3'
   gem 'rake', '~> 13.0'
   gem 'rake-compiler', '~> 1.1'
-  gem 'rake-compiler-dock', '~> 1.0'
+  gem 'rake-compiler-dock', '~> 1.0.pre'
   gem 'rspec', '~> 3.0'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ BUILD_EXT_DIR = File.join(BUILD_DIR, "#{RbConfig::CONFIG['arch']}", 'ffi_c', RUB
 
 gem_spec = Bundler.load_gemspec('ffi.gemspec')
 
-RSpec::Core::RakeTask.new(:spec => :compile) do |config|
+RSpec::Core::RakeTask.new(:spec) do |config|
   config.rspec_opts = YAML.load_file 'spec/spec.opts'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -84,10 +84,22 @@ end
 task 'gem:java' => 'java:gem'
 
 FfiGemHelper.install_tasks
-# Register windows gems to be pushed to rubygems.org
-Bundler::GemHelper.instance.cross_platforms = %w[x86-mingw32 x64-mingw-ucrt x64-mingw32]
-# These platforms are not yet enabled, since there are issues on musl-based distors (alpine-linux):
-# + %w[x86-linux x86_64-linux arm-linux aarch64-linux x86_64-darwin arm64-darwin]
+# Register binary gems to be pushed to rubygems.org
+Bundler::GemHelper.instance.cross_platforms = %w[
+  x86-mingw32
+  x64-mingw-ucrt
+  x64-mingw32
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-linux-gnu
+  x86_64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  x86_64-darwin
+  arm64-darwin
+]
 
 if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   require 'rake/extensiontask'

--- a/ext/ffi_c/libffi.darwin.mk
+++ b/ext/ffi_c/libffi.darwin.mk
@@ -37,7 +37,7 @@ $(LIBFFI):
 		echo "Configuring libffi"; \
 		cd "$(LIBFFI_BUILD_DIR)" && \
 		/usr/bin/env CC="$(CC)" LD="$(LD)" CFLAGS="$(LIBFFI_CFLAGS)" GREP_OPTIONS="" \
-		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) > /dev/null; \
+		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) --disable-shared --enable-static > /dev/null; \
 	fi
 	cd "$(LIBFFI_BUILD_DIR)" && $(MAKE)
 
@@ -56,7 +56,7 @@ build_ffi = \
 	    echo "Configuring libffi for $(1)"; \
 	    cd "$(BUILD_DIR)"/libffi-$(1) && \
 	      env CC="$(CCACHE) $(CC)" CFLAGS="-arch $(1) $(LIBFFI_CFLAGS)" LDFLAGS="-arch $(1)" \
-		$(LIBFFI_CONFIGURE) --host=$(1)-apple-darwin > /dev/null; \
+		$(LIBFFI_CONFIGURE) --host=$(1)-apple-darwin --disable-shared --enable-static > /dev/null; \
 	fi); \
 	$(MAKE) -C "$(BUILD_DIR)"/libffi-$(1)
 

--- a/spec/env/Dockerfile.alpine
+++ b/spec/env/Dockerfile.alpine
@@ -1,0 +1,17 @@
+ARG from_image
+FROM ${from_image}
+
+RUN uname -a
+RUN apk add ruby ruby-etc ruby-rake git gcc make musl-dev gcompat
+
+RUN ruby --version
+RUN ruby -e 'puts File.read("/proc/#{Process.pid}/maps")'
+RUN gem env
+RUN gem inst bundler --conservative
+
+WORKDIR /build
+
+CMD ruby -e "puts Gem::Platform.local.to_s" && \
+  gem install --local *.gem --verbose --no-document && \
+  bundle install && \
+  ruby -rffi -S rake test

--- a/spec/env/Dockerfile.alpine
+++ b/spec/env/Dockerfile.alpine
@@ -11,7 +11,8 @@ RUN gem inst bundler --conservative
 
 WORKDIR /build
 
-CMD ruby -e "puts Gem::Platform.local.to_s" && \
+CMD ruby -v && \
+  ruby -e "puts Gem::Platform.local.to_s" && \
   gem install --local *.gem --verbose --no-document && \
   bundle install && \
   ruby -rffi -S rake test

--- a/spec/env/Dockerfile.centos
+++ b/spec/env/Dockerfile.centos
@@ -1,0 +1,23 @@
+ARG from_image
+FROM ${from_image}
+
+RUN uname -a
+
+# Change download address of Centos-8 which is EOL
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN yum install -y ruby git gcc make
+
+RUN ruby --version
+RUN gem env
+
+# centos-8 comes with Ruby 2.5, and this is the last version of bundler that supports it
+RUN gem install bundler -v2.2.28
+
+WORKDIR /build
+
+CMD ruby -e "puts Gem::Platform.local.to_s" && \
+  gem install --local *.gem --verbose --no-document && \
+  bundle install && \
+  ruby -rffi -S rake test

--- a/spec/env/Dockerfile.centos
+++ b/spec/env/Dockerfile.centos
@@ -17,7 +17,8 @@ RUN gem install bundler -v2.2.28
 
 WORKDIR /build
 
-CMD ruby -e "puts Gem::Platform.local.to_s" && \
+CMD ruby -v && \
+  ruby -e "puts Gem::Platform.local.to_s" && \
   gem install --local *.gem --verbose --no-document && \
   bundle install && \
   ruby -rffi -S rake test

--- a/spec/env/Dockerfile.centos
+++ b/spec/env/Dockerfile.centos
@@ -12,6 +12,8 @@ RUN yum install -y ruby git gcc make
 RUN ruby --version
 RUN gem env
 
+RUN gem install rubygems-update:3.3.26 --no-doc && \
+  update_rubygems
 # centos-8 comes with Ruby 2.5, and this is the last version of bundler that supports it
 RUN gem install bundler -v2.2.28
 

--- a/spec/env/Dockerfile.debian
+++ b/spec/env/Dockerfile.debian
@@ -19,7 +19,8 @@ RUN gem inst bundler
 
 WORKDIR /build
 
-CMD  ruby -e "puts Gem::Platform.local.to_s" && \
+CMD  ruby -v && \
+  ruby -e "puts Gem::Platform.local.to_s" && \
   gem install --local *.gem --verbose --no-document && \
   bundle install && \
   ruby -rffi -S rake test

--- a/spec/env/Dockerfile.debian
+++ b/spec/env/Dockerfile.debian
@@ -15,6 +15,8 @@ RUN apt-get update -qq && \
 
 RUN ruby --version
 RUN gem env
+RUN gem install rubygems-update --no-doc && \
+  update_rubygems
 RUN gem inst bundler
 
 WORKDIR /build

--- a/spec/env/Dockerfile.debian
+++ b/spec/env/Dockerfile.debian
@@ -1,0 +1,25 @@
+ARG from_image
+FROM ${from_image}
+
+# To prevent installed tzdata deb package to show interactive dialog.
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq \
+  -o Dpkg::Options::='--force-confnew' \
+  ruby \
+  git \
+  gcc \
+  make
+
+RUN ruby --version
+RUN gem env
+RUN gem inst bundler
+
+WORKDIR /build
+
+CMD  ruby -e "puts Gem::Platform.local.to_s" && \
+  gem install --local *.gem --verbose --no-document && \
+  bundle install && \
+  ruby -rffi -S rake test

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -928,7 +928,12 @@ module CallbackInteropSpecs
       it "C outside ffi call stack does not deadlock [#527]" do
         skip "not yet supported on TruffleRuby" if RUBY_ENGINE == "truffleruby"
 
-        out = external_run(RbConfig.ruby, "embed-test/embed-test.rb")
+        begin
+          out = external_run(RbConfig.ruby, "embed-test/embed-test.rb")
+        rescue => err
+          skip "missing ruby development headers" if /can't find header files for ruby/ =~ err.to_s
+          raise
+        end
         expect(out).to match(/callback called with \["hello", 5, 0\]/)
       end
     end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -102,7 +102,7 @@ describe "Library" do
       }.to raise_error(LoadError)
     end
 
-    it "interprets INPUT() in linker scripts", unless: FFI::Platform.windows? || FFI::Platform.mac? do
+    it "interprets INPUT() in linker scripts", if: FFI::Platform::IS_GNU && !FFI::Platform.windows? && !FFI::Platform.mac? do
       path = File.dirname(TestLibrary::PATH)
       file = File.basename(TestLibrary::PATH)
       script = File.join(path, "ldscript.so")

--- a/spec/ffi/long_double_spec.rb
+++ b/spec/ffi/long_double_spec.rb
@@ -47,4 +47,4 @@ describe ":long_double arguments and return values" do
       expect(v).to be_within(0.01).of(0.1)
     end
   end
-end unless ['truffleruby', 'jruby'].include?(RUBY_ENGINE)
+end unless ['truffleruby', 'jruby'].include?(RUBY_ENGINE) || /x64-mingw32/ =~ RUBY_PLATFORM


### PR DESCRIPTION
This adds binary gems for more platforms. Until now only Mingw platforms were provided. This PR adds many more platforms for Linux and Darwin on arm, x86 and x86_64 architectures. It also adds proper build tasks to CI and test tasks for binary gems on various platforms.