### PR TITLE
Protect FFI::Function with Write Barrier

### DIFF
--- a/ext/ffi_c/Buffer.c
+++ b/ext/ffi_c/Buffer.c
@@ -49,9 +49,19 @@ typedef struct Buffer {
 
 static VALUE buffer_allocate(VALUE klass);
 static VALUE buffer_initialize(int argc, VALUE* argv, VALUE self);
-static void buffer_release(Buffer* ptr);
-static void buffer_mark(Buffer* ptr);
+static void buffer_release(void* data);
+static void buffer_mark(void* data);
 static VALUE buffer_free(VALUE self);
+
+static const rb_data_type_t buffer_data_type = {
+    .wrap_struct_name = "FFI::Buffer",
+    .function = {
+        .dmark = buffer_mark,
+        .dfree = buffer_release,
+        .dsize = NULL,
+    },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
 
 static VALUE BufferClass = Qnil;
 
@@ -61,7 +71,7 @@ buffer_allocate(VALUE klass)
     Buffer* buffer;
     VALUE obj;
 
-    obj = Data_Make_Struct(klass, Buffer, NULL, buffer_release, buffer);
+    obj = TypedData_Make_Struct(klass, Buffer, &buffer_data_type, buffer);
     buffer->data.rbParent = Qnil;
     buffer->memory.flags = MEM_RD | MEM_WR;
 
@@ -69,8 +79,9 @@ buffer_allocate(VALUE klass)
 }
 
 static void
-buffer_release(Buffer* ptr)
+buffer_release(void *data)
 {
+    Buffer* ptr = (Buffer *)data;
     if ((ptr->memory.flags & MEM_EMBED) == 0 && ptr->data.storage != NULL) {
         xfree(ptr->data.storage);
         ptr->data.storage = NULL;
@@ -95,7 +106,7 @@ buffer_initialize(int argc, VALUE* argv, VALUE self)
     Buffer* p;
     int nargs;
 
-    Data_Get_Struct(self, Buffer, p);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, p);
 
     nargs = rb_scan_args(argc, argv, "12", &rbSize, &rbCount, &rbClear);
     p->memory.typeSize = rbffi_type_size(rbSize);
@@ -138,7 +149,7 @@ buffer_initialize_copy(VALUE self, VALUE other)
     AbstractMemory* src;
     Buffer* dst;
     
-    Data_Get_Struct(self, Buffer, dst);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, dst);
     src = rbffi_AbstractMemory_Cast(other, BufferClass);
     if ((dst->memory.flags & MEM_EMBED) == 0 && dst->data.storage != NULL) {
         xfree(dst->data.storage);
@@ -172,10 +183,10 @@ slice(VALUE self, long offset, long len)
     Buffer* result;
     VALUE obj = Qnil;
     
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
     checkBounds(&ptr->memory, offset, len);
 
-    obj = Data_Make_Struct(BufferClass, Buffer, buffer_mark, -1, result);
+    obj = TypedData_Make_Struct(BufferClass, Buffer, &buffer_data_type, result);
     result->memory.address = ptr->memory.address + offset;
     result->memory.size = len;
     result->memory.flags = ptr->memory.flags;
@@ -197,7 +208,7 @@ buffer_plus(VALUE self, VALUE rbOffset)
     Buffer* ptr;
     long offset = NUM2LONG(rbOffset);
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
 
     return slice(self, offset, ptr->memory.size - offset);
 }
@@ -226,7 +237,7 @@ buffer_inspect(VALUE self)
     char tmp[100];
     Buffer* ptr;
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
 
     snprintf(tmp, sizeof(tmp), "#<FFI:Buffer:%p address=%p size=%ld>", ptr, ptr->memory.address, ptr->memory.size);
     
@@ -255,7 +266,7 @@ buffer_order(int argc, VALUE* argv, VALUE self)
 {
     Buffer* ptr;
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
     if (argc == 0) {
         int order = (ptr->memory.flags & MEM_SWAP) == 0 ? BYTE_ORDER : SWAPPED_ORDER;
         return order == BIG_ENDIAN ? ID2SYM(rb_intern("big")) : ID2SYM(rb_intern("little"));
@@ -279,7 +290,7 @@ buffer_order(int argc, VALUE* argv, VALUE self)
             Buffer* p2;
             VALUE retval = slice(self, 0, ptr->memory.size);
 
-            Data_Get_Struct(retval, Buffer, p2);
+            TypedData_Get_Struct(retval, Buffer, &buffer_data_type, p2);
             p2->memory.flags |= MEM_SWAP;
             return retval;
         }
@@ -294,7 +305,7 @@ buffer_free(VALUE self)
 {
     Buffer* ptr;
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
     if ((ptr->memory.flags & MEM_EMBED) == 0 && ptr->data.storage != NULL) {
         xfree(ptr->data.storage);
         ptr->data.storage = NULL;
@@ -304,9 +315,12 @@ buffer_free(VALUE self)
 }
 
 static void
-buffer_mark(Buffer* ptr)
+buffer_mark(void *data)
 {
-    rb_gc_mark(ptr->data.rbParent);
+    Buffer* ptr = (Buffer *)data;
+    if ((ptr->memory.flags & MEM_EMBED) != 0) {
+        rb_gc_mark(ptr->data.rbParent);
+    }
 }
 
 void

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -439,7 +439,7 @@ getPointer(VALUE value, int type)
 
         VALUE ptr = rb_funcall2(value, id_to_ptr, 0, NULL);
         if (rb_obj_is_kind_of(ptr, rbffi_AbstractMemoryClass) && TYPE(ptr) == T_DATA) {
-            return ((AbstractMemory *) DATA_PTR(ptr))->address;
+            return MEMORY_PTR(ptr);
         }
         rb_raise(rb_eArgError, "to_ptr returned an invalid pointer");
     }
@@ -465,15 +465,13 @@ callback_param(VALUE proc, VALUE cbInfo)
 
     /* Handle Function pointers here */
     if (rb_obj_is_kind_of(proc, rbffi_FunctionClass)) {
-        AbstractMemory* ptr;
-        Data_Get_Struct(proc, AbstractMemory, ptr);
-        return ptr->address;
+        return MEMORY_PTR(proc);
     }
 
     callback = rbffi_Function_ForProc(cbInfo, proc);
     RB_GC_GUARD(callback);
 
-    return ((AbstractMemory *) DATA_PTR(callback))->address;
+    return MEMORY_PTR(callback);
 }
 
 

--- a/ext/ffi_c/Pointer.h
+++ b/ext/ffi_c/Pointer.h
@@ -38,11 +38,6 @@ extern "C" {
 
 #include "AbstractMemory.h"
 
-extern void rbffi_Pointer_Init(VALUE moduleFFI);
-extern VALUE rbffi_Pointer_NewInstance(void* addr);
-extern VALUE rbffi_PointerClass;
-extern VALUE rbffi_NullPointerSingleton;
-
 typedef struct Pointer {
     AbstractMemory memory;
     VALUE rbParent;
@@ -50,6 +45,12 @@ typedef struct Pointer {
     bool autorelease;
     bool allocated;
 } Pointer;
+
+extern void rbffi_Pointer_Init(VALUE moduleFFI);
+extern VALUE rbffi_Pointer_NewInstance(void* addr);
+extern Pointer *rbffi_Pointer_Cast(VALUE obj, VALUE klass);
+extern VALUE rbffi_PointerClass;
+extern VALUE rbffi_NullPointerSingleton;
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC.

The downside is that the `RB_BJ_WRITE` macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

cc @peterzhu2118 

NB: The test suite use an X86_64 fixtures, so I can't run it locally. I did check that the extension does compile though.