### PR TITLE
Convert FFI::Type and descendants to TypedData

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -345,7 +345,7 @@ memory_get(VALUE self, VALUE type_name, VALUE offset)
     if(NIL_P(nType)) goto undefined_type;
 
     Data_Get_Struct(self, AbstractMemory, ptr);
-    Data_Get_Struct(nType, Type, type);
+    TypedData_Get_Struct(nType, Type, &rbffi_type_data_type, type);
 
     MemoryOp *op = get_memory_op(type);
     if(op == NULL) goto undefined_type;
@@ -377,7 +377,7 @@ memory_put(VALUE self, VALUE type_name, VALUE offset, VALUE value)
     if(NIL_P(nType)) goto undefined_type;
 
     Data_Get_Struct(self, AbstractMemory, ptr);
-    Data_Get_Struct(nType, Type, type);
+    TypedData_Get_Struct(nType, Type, &rbffi_type_data_type, type);
 
     MemoryOp *op = get_memory_op(type);
     if(op == NULL) goto undefined_type;

--- a/ext/ffi_c/ArrayType.h
+++ b/ext/ffi_c/ArrayType.h
@@ -48,6 +48,7 @@ typedef struct ArrayType_ {
 } ArrayType;
 
 extern void rbffi_ArrayType_Init(VALUE moduleFFI);
+extern const rb_data_type_t rbffi_array_type_data_type;
 extern VALUE rbffi_ArrayTypeClass;
 
 

--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -302,7 +302,7 @@ function_init(VALUE self, VALUE rbFunctionInfo, VALUE rbProc)
 
     fn->rbFunctionInfo = rbFunctionInfo;
 
-    Data_Get_Struct(fn->rbFunctionInfo, FunctionType, fn->info);
+    TypedData_Get_Struct(fn->rbFunctionInfo, FunctionType, &rbffi_fntype_data_type, fn->info);
 
     if (rb_obj_is_kind_of(rbProc, rbffi_PointerClass)) {
         Pointer* orig;

--- a/ext/ffi_c/Function.h
+++ b/ext/ffi_c/Function.h
@@ -68,6 +68,7 @@ struct FunctionType_ {
     bool hasStruct;
 };
 
+extern const rb_data_type_t rbffi_fntype_data_type;
 extern VALUE rbffi_FunctionTypeClass, rbffi_FunctionClass;
 
 void rbffi_Function_Init(VALUE moduleFFI);

--- a/ext/ffi_c/MappedType.h
+++ b/ext/ffi_c/MappedType.h
@@ -50,7 +50,6 @@ void rbffi_MappedType_Init(VALUE moduleFFI);
 
 extern VALUE rbffi_MappedTypeClass;
 
-
 #ifdef	__cplusplus
 }
 #endif

--- a/ext/ffi_c/Struct.c
+++ b/ext/ffi_c/Struct.c
@@ -123,7 +123,7 @@ struct_initialize(int argc, VALUE* argv, VALUE self)
         rb_raise(rb_eRuntimeError, "Invalid Struct layout");
     }
 
-    Data_Get_Struct(s->rbLayout, StructLayout, s->layout);
+    TypedData_Get_Struct(s->rbLayout, StructLayout, &rbffi_struct_layout_data_type, s->layout);
 
     if (rbPointer != Qnil) {
         s->pointer = MEMORY(rbPointer);
@@ -203,7 +203,7 @@ struct_layout(VALUE self)
 
     if (s->layout == NULL) {
         s->rbLayout = struct_class_layout(CLASS_OF(self));
-        Data_Get_Struct(s->rbLayout, StructLayout, s->layout);
+        TypedData_Get_Struct(s->rbLayout, StructLayout, &rbffi_struct_layout_data_type, s->layout);
     }
 
     return s->layout;
@@ -291,7 +291,7 @@ struct_field(Struct* s, VALUE fieldName)
         }
         /* Write the retrieved coder to the cache */
         p_ce->fieldName = fieldName;
-        p_ce->field = (StructField *) DATA_PTR(rbField);
+        TypedData_Get_Struct(rbField, StructField, &rbffi_struct_field_data_type, p_ce->field);
     }
 
     return p_ce->field;
@@ -432,7 +432,7 @@ struct_set_layout(VALUE self, VALUE layout)
         return Qnil;
     }
 
-    Data_Get_Struct(layout, StructLayout, s->layout);
+    TypedData_Get_Struct(layout, StructLayout, &rbffi_struct_layout_data_type, s->layout);
     rb_ivar_set(self, id_layout_ivar, layout);
 
     return self;
@@ -526,9 +526,9 @@ inline_array_initialize(VALUE self, VALUE rbMemory, VALUE rbField)
     array->rbField = rbField;
 
     Data_Get_Struct(rbMemory, AbstractMemory, array->memory);
-    Data_Get_Struct(rbField, StructField, array->field);
-    Data_Get_Struct(array->field->rbType, ArrayType, array->arrayType);
-    Data_Get_Struct(array->arrayType->rbComponentType, Type, array->componentType);
+    TypedData_Get_Struct(rbField, StructField, &rbffi_struct_field_data_type, array->field);
+    TypedData_Get_Struct(array->field->rbType, ArrayType, &rbffi_array_type_data_type, array->arrayType);
+    TypedData_Get_Struct(array->arrayType->rbComponentType, Type, &rbffi_type_data_type, array->componentType);
 
     array->op = get_memory_op(array->componentType);
     if (array->op == NULL && array->componentType->nativeType == NATIVE_MAPPED) {
@@ -641,7 +641,7 @@ inline_array_aset(VALUE self, VALUE rbIndex, VALUE rbValue)
 
     } else {
         ArrayType* arrayType;
-        Data_Get_Struct(array->field->rbType, ArrayType, arrayType);
+        TypedData_Get_Struct(array->field->rbType, ArrayType, &rbffi_array_type_data_type, arrayType);
 
         rb_raise(rb_eArgError, "set not supported for %s", rb_obj_classname(arrayType->rbComponentType));
         return Qnil;

--- a/ext/ffi_c/Struct.h
+++ b/ext/ffi_c/Struct.h
@@ -42,6 +42,9 @@ extern "C" {
 
     extern void rbffi_Struct_Init(VALUE ffiModule);
     extern void rbffi_StructLayout_Init(VALUE ffiModule);
+    extern const rb_data_type_t rbffi_struct_layout_data_type;
+    extern const rb_data_type_t rbffi_struct_field_data_type;
+
     typedef struct StructField_ StructField;
     typedef struct StructLayout_ StructLayout;
     typedef struct Struct_ Struct;

--- a/ext/ffi_c/Type.h
+++ b/ext/ffi_c/Type.h
@@ -53,6 +53,8 @@ struct Type_ {
 extern VALUE rbffi_TypeClass;
 extern VALUE rbffi_Type_Lookup(VALUE type);
 
+extern const rb_data_type_t rbffi_type_data_type;
+
 #ifdef	__cplusplus
 }
 #endif

--- a/ext/ffi_c/Variadic.c
+++ b/ext/ffi_c/Variadic.c
@@ -128,7 +128,7 @@ variadic_initialize(VALUE self, VALUE rbFunction, VALUE rbParameterTypes, VALUE 
         rb_raise(rb_eTypeError, "Invalid return type (%s)", RSTRING_PTR(typeName));
     }
 
-    Data_Get_Struct(rbReturnType, Type, invoker->returnType);
+    TypedData_Get_Struct(rbReturnType, Type, &rbffi_type_data_type, invoker->returnType);
 
     invoker->paramCount = -1;
 
@@ -142,7 +142,7 @@ variadic_initialize(VALUE self, VALUE rbFunction, VALUE rbParameterTypes, VALUE 
             VALUE typeName = rb_funcall2(entry, rb_intern("inspect"), 0, NULL);
             rb_raise(rb_eTypeError, "Invalid parameter type (%s)", RSTRING_PTR(typeName));
         }
-        Data_Get_Struct(rbType, Type, type);
+        TypedData_Get_Struct(rbType, Type, &rbffi_type_data_type, type);
         if (type->nativeType != NATIVE_VARARGS) {
             rb_ary_push(fixed, entry);
         }
@@ -192,25 +192,25 @@ variadic_invoke(VALUE self, VALUE parameterTypes, VALUE parameterValues)
         if (!rb_obj_is_kind_of(rbType, rbffi_TypeClass)) {
             rb_raise(rb_eTypeError, "wrong type.  Expected (FFI::Type)");
         }
-        Data_Get_Struct(rbType, Type, paramTypes[i]);
+        TypedData_Get_Struct(rbType, Type, &rbffi_type_data_type, paramTypes[i]);
 
         switch (paramTypes[i]->nativeType) {
             case NATIVE_INT8:
             case NATIVE_INT16:
             case NATIVE_INT32:
                 rbType = rb_const_get(rbffi_TypeClass, rb_intern("INT32"));
-                Data_Get_Struct(rbType, Type, paramTypes[i]);
+                TypedData_Get_Struct(rbType, Type, &rbffi_type_data_type, paramTypes[i]);
                 break;
             case NATIVE_UINT8:
             case NATIVE_UINT16:
             case NATIVE_UINT32:
                 rbType = rb_const_get(rbffi_TypeClass, rb_intern("UINT32"));
-                Data_Get_Struct(rbType, Type, paramTypes[i]);
+                TypedData_Get_Struct(rbType, Type, &rbffi_type_data_type, paramTypes[i]);
                 break;
 
             case NATIVE_FLOAT32:
                 rbType = rb_const_get(rbffi_TypeClass, rb_intern("DOUBLE"));
-                Data_Get_Struct(rbType, Type, paramTypes[i]);
+                TypedData_Get_Struct(rbType, Type, &rbffi_type_data_type, paramTypes[i]);
                 break;
 
             case NATIVE_FUNCTION:

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -33,7 +33,7 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   $CFLAGS.gsub!(/[\s+]-ansi/, '')
   $CFLAGS.gsub!(/[\s+]-std=[^\s]+/, '')
   # solaris 10 needs -c99 for <stdbool.h>
-  $CFLAGS << " -std=c99" if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.11)/
+  $CFLAGS << " -g -std=c99" if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.11)/
 
   # Check whether we use system libffi
   system_libffi = enable_config('system-libffi', :try)


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/pull/991

The old untyped DATA API is soft deprecated and
this new one open the door to write barriers, compaction, memsize etc.

NB: As mentioned in https://github.com/ffi/ffi/pull/991, I'm trying to do the smallest changes possible so that it's easier to spot if I made a mistake. In this case because of the "inheritance" between types, I had no choice but to convert them all at once.

I'm also not particularly happy to have to expose some of these `data_type_t`, but I followed the existing convention of prefixing them with `rbffi_`.