### PR TITLE
Convert FFI::AbstractMemory and descendants to TypedData

### DIFF
--- a/ext/ffi_c/AbstractMemory.h
+++ b/ext/ffi_c/AbstractMemory.h
@@ -86,6 +86,7 @@ struct AbstractMemory_ {
 };
 
 
+extern const rb_data_type_t rbffi_abstract_memory_data_type;
 extern VALUE rbffi_AbstractMemoryClass;
 extern MemoryOps rbffi_AbstractMemoryOps;
 

--- a/ext/ffi_c/Buffer.c
+++ b/ext/ffi_c/Buffer.c
@@ -49,9 +49,32 @@ typedef struct Buffer {
 
 static VALUE buffer_allocate(VALUE klass);
 static VALUE buffer_initialize(int argc, VALUE* argv, VALUE self);
-static void buffer_release(Buffer* ptr);
-static void buffer_mark(Buffer* ptr);
+static void buffer_release(void *data);
+static void buffer_mark(void *data);
 static VALUE buffer_free(VALUE self);
+
+static const rb_data_type_t buffer_data_type = {
+    .wrap_struct_name = "FFI::Buffer",
+    .function = {
+        .dmark = buffer_mark,
+        .dfree = RUBY_TYPED_DEFAULT_FREE,
+        .dsize = NULL,
+    },
+    .parent = &rbffi_abstract_memory_data_type,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static const rb_data_type_t allocated_buffer_data_type = {
+    .wrap_struct_name = "FFI::Buffer(allocated)",
+    .function = {
+        .dmark = NULL,
+        .dfree = buffer_release,
+        .dsize = NULL,
+    },
+    .parent = &buffer_data_type,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 
 static VALUE BufferClass = Qnil;
 
@@ -61,7 +84,7 @@ buffer_allocate(VALUE klass)
     Buffer* buffer;
     VALUE obj;
 
-    obj = Data_Make_Struct(klass, Buffer, NULL, buffer_release, buffer);
+    obj = TypedData_Make_Struct(klass, Buffer, &allocated_buffer_data_type, buffer);
     buffer->data.rbParent = Qnil;
     buffer->memory.flags = MEM_RD | MEM_WR;
 
@@ -69,8 +92,9 @@ buffer_allocate(VALUE klass)
 }
 
 static void
-buffer_release(Buffer* ptr)
+buffer_release(void *data)
 {
+    Buffer *ptr = (Buffer *)data;
     if ((ptr->memory.flags & MEM_EMBED) == 0 && ptr->data.storage != NULL) {
         xfree(ptr->data.storage);
         ptr->data.storage = NULL;
@@ -95,7 +119,7 @@ buffer_initialize(int argc, VALUE* argv, VALUE self)
     Buffer* p;
     int nargs;
 
-    Data_Get_Struct(self, Buffer, p);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, p);
 
     nargs = rb_scan_args(argc, argv, "12", &rbSize, &rbCount, &rbClear);
     p->memory.typeSize = rbffi_type_size(rbSize);
@@ -137,8 +161,8 @@ buffer_initialize_copy(VALUE self, VALUE other)
 {
     AbstractMemory* src;
     Buffer* dst;
-    
-    Data_Get_Struct(self, Buffer, dst);
+
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, dst);
     src = rbffi_AbstractMemory_Cast(other, BufferClass);
     if ((dst->memory.flags & MEM_EMBED) == 0 && dst->data.storage != NULL) {
         xfree(dst->data.storage);
@@ -171,11 +195,11 @@ slice(VALUE self, long offset, long len)
     Buffer* ptr;
     Buffer* result;
     VALUE obj = Qnil;
-    
-    Data_Get_Struct(self, Buffer, ptr);
+
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
     checkBounds(&ptr->memory, offset, len);
 
-    obj = Data_Make_Struct(BufferClass, Buffer, buffer_mark, -1, result);
+    obj = TypedData_Make_Struct(BufferClass, Buffer, &buffer_data_type, result);
     result->memory.address = ptr->memory.address + offset;
     result->memory.size = len;
     result->memory.flags = ptr->memory.flags;
@@ -197,7 +221,7 @@ buffer_plus(VALUE self, VALUE rbOffset)
     Buffer* ptr;
     long offset = NUM2LONG(rbOffset);
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
 
     return slice(self, offset, ptr->memory.size - offset);
 }
@@ -226,7 +250,7 @@ buffer_inspect(VALUE self)
     char tmp[100];
     Buffer* ptr;
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
 
     snprintf(tmp, sizeof(tmp), "#<FFI:Buffer:%p address=%p size=%ld>", ptr, ptr->memory.address, ptr->memory.size);
     
@@ -255,7 +279,7 @@ buffer_order(int argc, VALUE* argv, VALUE self)
 {
     Buffer* ptr;
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
     if (argc == 0) {
         int order = (ptr->memory.flags & MEM_SWAP) == 0 ? BYTE_ORDER : SWAPPED_ORDER;
         return order == BIG_ENDIAN ? ID2SYM(rb_intern("big")) : ID2SYM(rb_intern("little"));
@@ -279,7 +303,7 @@ buffer_order(int argc, VALUE* argv, VALUE self)
             Buffer* p2;
             VALUE retval = slice(self, 0, ptr->memory.size);
 
-            Data_Get_Struct(retval, Buffer, p2);
+            TypedData_Get_Struct(retval, Buffer, &buffer_data_type, p2);
             p2->memory.flags |= MEM_SWAP;
             return retval;
         }
@@ -294,7 +318,7 @@ buffer_free(VALUE self)
 {
     Buffer* ptr;
 
-    Data_Get_Struct(self, Buffer, ptr);
+    TypedData_Get_Struct(self, Buffer, &buffer_data_type, ptr);
     if ((ptr->memory.flags & MEM_EMBED) == 0 && ptr->data.storage != NULL) {
         xfree(ptr->data.storage);
         ptr->data.storage = NULL;
@@ -304,8 +328,9 @@ buffer_free(VALUE self)
 }
 
 static void
-buffer_mark(Buffer* ptr)
+buffer_mark(void *data)
 {
+    Buffer *ptr = (Buffer *)data;
     rb_gc_mark(ptr->data.rbParent);
 }
 

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -420,7 +420,9 @@ getPointer(VALUE value, int type)
 {
     if (likely(type == T_DATA && rb_obj_is_kind_of(value, rbffi_AbstractMemoryClass))) {
 
-        return ((AbstractMemory *) DATA_PTR(value))->address;
+        AbstractMemory *mem;
+        TypedData_Get_Struct(value, AbstractMemory, &rbffi_abstract_memory_data_type, mem);
+        return mem->address;
 
     } else if (type == T_DATA && rb_obj_is_kind_of(value, rbffi_StructClass)) {
 
@@ -439,7 +441,9 @@ getPointer(VALUE value, int type)
 
         VALUE ptr = rb_funcall2(value, id_to_ptr, 0, NULL);
         if (rb_obj_is_kind_of(ptr, rbffi_AbstractMemoryClass) && TYPE(ptr) == T_DATA) {
-            return ((AbstractMemory *) DATA_PTR(ptr))->address;
+            AbstractMemory *mem;
+            TypedData_Get_Struct(ptr, AbstractMemory, &rbffi_abstract_memory_data_type, mem);
+            return mem->address;
         }
         rb_raise(rb_eArgError, "to_ptr returned an invalid pointer");
     }
@@ -466,14 +470,16 @@ callback_param(VALUE proc, VALUE cbInfo)
     /* Handle Function pointers here */
     if (rb_obj_is_kind_of(proc, rbffi_FunctionClass)) {
         AbstractMemory* ptr;
-        Data_Get_Struct(proc, AbstractMemory, ptr);
+        TypedData_Get_Struct(proc, AbstractMemory, &rbffi_abstract_memory_data_type, ptr);
         return ptr->address;
     }
 
     callback = rbffi_Function_ForProc(cbInfo, proc);
     RB_GC_GUARD(callback);
 
-    return ((AbstractMemory *) DATA_PTR(callback))->address;
+    AbstractMemory *mem;
+    TypedData_Get_Struct(callback, AbstractMemory, &rbffi_abstract_memory_data_type, mem);
+    return mem->address;
 }
 
 

--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -54,13 +54,25 @@ typedef struct LibrarySymbol_ {
     VALUE name;
 } LibrarySymbol;
 
+
 static VALUE library_initialize(VALUE self, VALUE libname, VALUE libflags);
 static void library_free(Library* lib);
 
 
 static VALUE symbol_allocate(VALUE klass);
 static VALUE symbol_new(VALUE library, void* address, VALUE name);
-static void symbol_mark(LibrarySymbol* sym);
+static void symbol_mark(void *data);
+
+static const rb_data_type_t library_symbol_data_type = {
+    .wrap_struct_name = "FFI::DynamicLibrary::Symbol",
+    .function = {
+        .dmark = symbol_mark,
+        .dfree = RUBY_TYPED_DEFAULT_FREE,
+        .dsize = NULL,
+    },
+    .parent = &rbffi_pointer_data_type,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
 
 static VALUE LibraryClass = Qnil, SymbolClass = Qnil;
 
@@ -198,7 +210,7 @@ static VALUE
 symbol_allocate(VALUE klass)
 {
     LibrarySymbol* sym;
-    VALUE obj = Data_Make_Struct(klass, LibrarySymbol, NULL, -1, sym);
+    VALUE obj = TypedData_Make_Struct(klass, LibrarySymbol, &library_symbol_data_type, sym);
     sym->name = Qnil;
     sym->library = Qnil;
     sym->base.rbParent = Qnil;
@@ -224,7 +236,7 @@ static VALUE
 symbol_new(VALUE library, void* address, VALUE name)
 {
     LibrarySymbol* sym;
-    VALUE obj = Data_Make_Struct(SymbolClass, LibrarySymbol, symbol_mark, -1, sym);
+    VALUE obj = TypedData_Make_Struct(SymbolClass, LibrarySymbol, &library_symbol_data_type, sym);
 
     sym->base.memory.address = address;
     sym->base.memory.size = LONG_MAX;
@@ -237,8 +249,9 @@ symbol_new(VALUE library, void* address, VALUE name)
 }
 
 static void
-symbol_mark(LibrarySymbol* sym)
+symbol_mark(void *data)
 {
+    LibrarySymbol *sym = (LibrarySymbol *)data;
     rb_gc_mark(sym->library);
     rb_gc_mark(sym->name);
 }
@@ -254,7 +267,7 @@ symbol_inspect(VALUE self)
     LibrarySymbol* sym;
     char buf[256];
 
-    Data_Get_Struct(self, LibrarySymbol, sym);
+    TypedData_Get_Struct(self, LibrarySymbol, &library_symbol_data_type, sym);
     snprintf(buf, sizeof(buf), "#<FFI::Library::Symbol name=%s address=%p>",
              StringValueCStr(sym->name), sym->base.memory.address);
     return rb_str_new2(buf);

--- a/ext/ffi_c/Pointer.h
+++ b/ext/ffi_c/Pointer.h
@@ -40,6 +40,7 @@ extern "C" {
 
 extern void rbffi_Pointer_Init(VALUE moduleFFI);
 extern VALUE rbffi_Pointer_NewInstance(void* addr);
+extern const rb_data_type_t rbffi_pointer_data_type;
 extern VALUE rbffi_PointerClass;
 extern VALUE rbffi_NullPointerSingleton;
 

--- a/ext/ffi_c/Struct.c
+++ b/ext/ffi_c/Struct.c
@@ -79,7 +79,9 @@ static ID id_get = 0, id_put = 0, id_to_ptr = 0, id_to_s = 0, id_layout = 0;
 static inline char*
 memory_address(VALUE self)
 {
-    return ((AbstractMemory *)DATA_PTR((self)))->address;
+    AbstractMemory *mem;
+    TypedData_Get_Struct(self, AbstractMemory, &rbffi_abstract_memory_data_type, mem);
+    return mem->address;
 }
 
 static VALUE
@@ -236,7 +238,7 @@ struct_malloc(Struct* s)
         rb_raise(rb_eRuntimeError, "invalid pointer in struct");
     }
 
-    s->pointer = (AbstractMemory *) DATA_PTR(s->rbPointer);
+    TypedData_Get_Struct(s->rbPointer, AbstractMemory, &rbffi_abstract_memory_data_type, s->pointer);
 }
 
 static void
@@ -384,7 +386,7 @@ struct_set_pointer(VALUE self, VALUE pointer)
 
 
     Data_Get_Struct(self, Struct, s);
-    Data_Get_Struct(pointer, AbstractMemory, memory);
+    TypedData_Get_Struct(pointer, AbstractMemory, &rbffi_abstract_memory_data_type, memory);
     layout = struct_layout(self);
 
     if ((int) layout->base.ffiType->size > memory->size) {
@@ -525,7 +527,7 @@ inline_array_initialize(VALUE self, VALUE rbMemory, VALUE rbField)
     array->rbMemory = rbMemory;
     array->rbField = rbField;
 
-    Data_Get_Struct(rbMemory, AbstractMemory, array->memory);
+    TypedData_Get_Struct(rbMemory, AbstractMemory, &rbffi_abstract_memory_data_type, array->memory);
     Data_Get_Struct(rbField, StructField, array->field);
     Data_Get_Struct(array->field->rbType, ArrayType, array->arrayType);
     Data_Get_Struct(array->arrayType->rbComponentType, Type, array->componentType);

--- a/ext/ffi_c/Types.c
+++ b/ext/ffi_c/Types.c
@@ -97,7 +97,7 @@ rbffi_NativeValue_ToRuby(Type* type, VALUE rbType, const void* ptr)
             AbstractMemory* mem;
             VALUE rbMemory = rbffi_MemoryPointer_NewInstance(1, sbv->base.ffiType->size, false);
 
-            Data_Get_Struct(rbMemory, AbstractMemory, mem);
+            TypedData_Get_Struct(rbMemory, AbstractMemory, &rbffi_abstract_memory_data_type, mem);
             memcpy(mem->address, ptr, sbv->base.ffiType->size);
             RB_GC_GUARD(rbMemory);
             RB_GC_GUARD(rbType);


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/pull/991

The old untyped DATA API is soft deprecated and
this new one open the door to write barriers, compaction, memsize etc.