### PR TITLE
Implement Write Barrier and dsize for FFI::FunctionType

### DIFF
--- a/spec/ffi/function_type_spec.rb
+++ b/spec/ffi/function_type_spec.rb
@@ -1,0 +1,27 @@
+#
+# This file is part of ruby-ffi.
+# For licensing, see LICENSE.SPECS
+#
+
+require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
+
+describe "FFI::FunctionType", skip: RUBY_ENGINE != "ruby" do
+  it 'is initialized with return type and a list of parameter types' do
+    function_type = FFI::FunctionType.new(:int, [ :char, :ulong ])
+    expect(function_type.result_type).to be == FFI::Type::Builtin::INT
+    expect(function_type.param_types).to be == [ FFI::Type::Builtin::CHAR, FFI::Type::Builtin::ULONG ]
+  end
+
+  it 'has a memsize function' do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    function_type = FFI::FunctionType.new(:int, [])
+    size = ObjectSpace.memsize_of(function_type)
+    expect(size).to be > base_size
+
+    base_size = size
+    function_type = FFI::FunctionType.new(:int, [:char])
+    size = ObjectSpace.memsize_of(function_type)
+    expect(size).to be > base_size
+  end
+end

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -5,6 +5,7 @@
 
 require_relative 'fixtures/compile'
 require 'timeout'
+require 'objspace'
 
 RSpec.configure do |c|
   c.filter_run_excluding :broken => true


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/pull/991

Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC.

The downside is that the RB_BJ_WRITE macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

This commit also implement a `dsize` function so that these instance report a more relevant size in various memory profilers.