### PR TITLE
Implement Write Barrier and dsize for FFI::Function

### DIFF
--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -103,4 +103,12 @@ describe FFI::Function do
     fp = FFI::Function.new(:int, [:int, :int], @libtest.find_function('testAdd'))
     expect { fp.free }.to raise_error RuntimeError
   end
+
+  it 'has a memsize function', skip: RUBY_ENGINE != "ruby" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    function = FFI::Function.new(:int, [:int, :int], @libtest.find_function('testAdd'))
+    size = ObjectSpace.memsize_of(function)
+    expect(size).to be > base_size
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/pull/991

Write barrier protected objects are allowed to be promoted to the old generation,
which means they only get marked on major GC.

The downside is that the RB_BJ_WRITE macro MUST be used to set references,
otherwise the referenced object may be garbaged collected.

This commit also implement a `dsize` function so that these instance report
a more relevant size in various memory profilers. It's not counting everything
because some types are opaque right now, so a larger refactoring would be needed.
