### PR TITLE
Implement Write Barrier and dsize for FFI::DynamicLibrary

### DIFF
--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -322,4 +322,21 @@ describe "Library" do
       expect(val[:data]).to eq(i)
     end
   end
+
+  describe "Symbol" do
+    before do
+      @libtest = FFI::DynamicLibrary.open(
+        TestLibrary::PATH,
+        FFI::DynamicLibrary::RTLD_LAZY | FFI::DynamicLibrary::RTLD_GLOBAL,
+      )
+    end
+
+    it "has a memsize function", skip: RUBY_ENGINE != "ruby" do
+      base_size = ObjectSpace.memsize_of(Object.new)
+
+      symbol = @libtest.find_symbol("gvar_gstruct_set")
+      size = ObjectSpace.memsize_of(symbol)
+      expect(size).to be > base_size
+    end
+  end
 end


### PR DESCRIPTION
And FFI::DynamicLibrary::Symbol
    
Ref: https://github.com/ffi/ffi/pull/991
    
Write barrier protected objects are allowed to be promoted to the old generation,
which means they only get marked on major GC.
    
The downside is that the RB_BJ_WRITE macro MUST be used to set references,
otherwise the referenced object may be garbaged collected.
    
This commit also implement a `dsize` function so that these instance report
a more relevant size in various memory profilers. It's not counting everything
because some types are opaque right now, so a larger refactoring would be needed.
    
While I was at it, I moved `Symbol.library` into the unused `Symbol.base.rbParent`
which seemed appropriate and saves a pointer.
