### PR TITLE
Implement Write Barrier and dsize for FFI::StructLayout

### DIFF
--- a/ext/ffi_c/Struct.c
+++ b/ext/ffi_c/Struct.c
@@ -304,7 +304,7 @@ struct_field(Struct* s, VALUE fieldName)
             rb_raise(rb_eArgError, "No such field '%s'", StringValueCStr(str));
         }
         /* Write the retrieved coder to the cache */
-        p_ce->fieldName = fieldName;
+        RB_OBJ_WRITE(s->rbLayout, &p_ce->fieldName, fieldName);
         TypedData_Get_Struct(rbField, StructField, &rbffi_struct_field_data_type, p_ce->field);
     }
 

--- a/ext/ffi_c/Struct.h
+++ b/ext/ffi_c/Struct.h
@@ -78,11 +78,12 @@ extern "C" {
         * This avoids full ruby hash lookups for repeated lookups.
         */
         #define FIELD_CACHE_LOOKUP(this, sym) ( &(this)->cache_row[((sym) >> 8) & 0xff] )
+        #define FIELD_CACHE_ROWS 0x100
 
         struct field_cache_entry {
           VALUE fieldName;
           StructField *field;
-        } cache_row[0x100];
+        } cache_row[FIELD_CACHE_ROWS];
 
         /** The number of reference tracking fields in this struct */
         int referenceFieldCount;

--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -203,8 +203,9 @@ module FFI
       #             :field3, :string
       #    end
       def layout(*spec)
-        warn "[DEPRECATION] Struct layout is already defined for class #{self.inspect}. Redefinition as in #{caller[0]} will be disallowed in ffi-2.0." if defined?(@layout)
         return @layout if spec.size == 0
+
+        warn "[DEPRECATION] Struct layout is already defined for class #{self.inspect}. Redefinition as in #{caller[0]} will be disallowed in ffi-2.0." if defined?(@layout)
 
         builder = StructLayoutBuilder.new
         builder.union = self < Union

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -1027,6 +1027,40 @@ describe "variable-length arrays" do
   end
 end
 
+describe "Struct memsize functions", skip: RUBY_ENGINE != "ruby" do
+  class SmallCustomStruct < FFI::Struct
+    layout :pointer, :pointer
+  end
+
+  class LargerCustomStruct < FFI::Struct
+    layout :pointer, :pointer,
+      :c, :char,
+      :i, :int
+  end
+
+  it "StructLayout has a memsize function" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    layout = SmallCustomStruct.layout
+    size = ObjectSpace.memsize_of(layout)
+    expect(size).to be > base_size
+    base_size = size
+
+    layout = LargerCustomStruct.layout
+    size = ObjectSpace.memsize_of(layout)
+    expect(size).to be > base_size
+  end
+
+  it "StructField has a memsize function" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    layout = SmallCustomStruct.layout
+    size = ObjectSpace.memsize_of(layout[:pointer])
+    expect(size).to be > base_size
+  end
+end
+
+
 describe "Struct order" do
   before :all do
     @struct = Class.new(FFI::Struct) do


### PR DESCRIPTION
And FFI::StructLayout::Field

Ref: https://github.com/ffi/ffi/pull/991

Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC.

The downside is that the RB_BJ_WRITE macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

This commit also implement a `dsize` function so that these instance report a more relevant size in various memory profilers.

I had to get rid of the `memset(0)` in `struct_layout_mark` has with Write Barriers it's not guaranteed that the layout will be marked before `fieldName` is moved.

I don't think it was a good fix anyway, it's better to mark these VALUE so the GC pin them. I think we could go back to an `st_table` and mark only the keys with `rb_mark_set`. But I didn't want to go down this rabbit hole.