### PR TITLE
Implement Write Barrier and dsize for FFI::Struct

### DIFF
--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -1027,6 +1027,19 @@ describe "variable-length arrays" do
   end
 end
 
+describe "Struct memsize", skip: RUBY_ENGINE != "ruby" do
+  it "has a memsize function" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    c = Class.new(FFI::Struct) do
+      layout :b, :bool
+    end
+    struct = c.new
+    size = ObjectSpace.memsize_of(struct)
+    expect(size).to be > base_size
+  end
+end
+
 describe "Struct order" do
   before :all do
     @struct = Class.new(FFI::Struct) do


### PR DESCRIPTION
And FFI::Struct::InlineArray.

Ref: https://github.com/ffi/ffi/pull/991

Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC.

The downside is that the RB_BJ_WRITE macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

This commit also implement a `dsize` function so that these instance report a more relevant size in various memory profilers.