### PR TITLE
Implement Write Barrier and dsize for FFI::Pointer

### DIFF
--- a/spec/ffi/buffer_spec.rb
+++ b/spec/ffi/buffer_spec.rb
@@ -285,3 +285,13 @@ describe "Buffer#initialize" do
     expect(block_executed).to be true
   end
 end
+
+describe "Buffer#memsize_of" do
+  it "has a memsize function", skip: RUBY_ENGINE != "ruby" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    buf = FFI::Buffer.new 14
+    size = ObjectSpace.memsize_of(buf)
+    expect(size).to be > base_size
+  end
+end

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -381,5 +381,13 @@ describe "AutoPointer" do
       expect(mptr[1].read_uint).to eq(0xcafebabe)
     end
   end
+
+  it "has a memsize function", skip: RUBY_ENGINE != "ruby" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    pointer = FFI::Pointer.new(:int, 0xdeadbeef)
+    size = ObjectSpace.memsize_of(pointer)
+    expect(size).to be > base_size
+  end
 end
 

--- a/spec/ffi/rbx/memory_pointer_spec.rb
+++ b/spec/ffi/rbx/memory_pointer_spec.rb
@@ -189,4 +189,12 @@ describe "MemoryPointer" do
     end
     expect(block_executed).to be true
   end
+
+  it "has a memsize function", skip: RUBY_ENGINE != "ruby" do
+    base_size = ObjectSpace.memsize_of(Object.new)
+
+    pointer = FFI::MemoryPointer.from_string("FFI is Awesome")
+    size = ObjectSpace.memsize_of(pointer)
+    expect(size).to be > base_size
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/pull/991

As well as FFI::MemoryPointer and FFI::AbstractMemory

Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC.

The downside is that the RB_BJ_WRITE macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

This commit also implement a dsize function so that these instance report a more relevant size in various memory profilers.

@larskanis I'm curious whether `FFI::AbstractMemory.new` is ever meant to be used? If I make it raise no test fail, and I really don't see what the usage would be. 

I'm tempted to just undefine the allocation function.