### PR TITLE
Implement the last missing Write Barriers and dsize

### DIFF
--- a/ext/ffi_c/LastError.c
+++ b/ext/ffi_c/LastError.c
@@ -91,14 +91,21 @@ thread_data_free(void *ptr)
 }
 
 #else
+static size_t
+thread_data_memsize(const void *data) {
+    return sizeof(ThreadData);
+}
+
 static const rb_data_type_t thread_data_data_type = {
     .wrap_struct_name = "FFI::ThreadData",
     .function = {
         .dmark = NULL,
         .dfree = RUBY_TYPED_DEFAULT_FREE,
-        .dsize = NULL,
+        .dsize = thread_data_memsize,
     },
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY
+    // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
+    // macro to update VALUE references, as to trigger write barriers.
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static ID id_thread_data;


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/pull/991

Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC.

The downside is that the RB_BJ_WRITE macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

This commit also implement a `dsize` function so that these instance report a more relevant size in various memory profilers. It's not counting everything because some types are opaque right now, so a larger refactoring would be needed.