### PR TITLE
Update libffi

### DIFF
--- a/ext/ffi_c/MethodHandle.c
+++ b/ext/ffi_c/MethodHandle.c
@@ -77,7 +77,9 @@
 static bool prep_trampoline(void* ctx, void* code, Closure* closure, char* errmsg, size_t errmsgsize);
 static long trampoline_size(void);
 
-#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__))
+#if defined(__x86_64__) && \
+    (defined(__linux__) || defined(__APPLE__)) && \
+    !USE_FFI_ALLOC
 # define CUSTOM_TRAMPOLINE 1
 #endif
 


### PR DESCRIPTION
Since libffi introduced static trampolines in commit https://github.com/libffi/libffi/commit/9ba559217bea0803263a9a9a0bafcf9203606f5b , it's necessary to use `ffi_prep_cif()` and `ffi_prep_closure_loc()` instead of our own optimized trampoline. Otherwise all functions attached to a `FFI::Library` module result in a segfault.

Using ffi's (classic or static) trampolines is somewhat slower than our optimized ones, but they are still faster than the alternative ruby code like this:

```ruby
module FFI
  class Function < Pointer
    def attach(mod, name)
      this = self
      body = -> *args, &block do
        this.call(*args, &block)
      end
      mod.define_method(name, body)
      mod.define_singleton_method(name, body)
      self
    end
  end
end
```

Fixes #989
