### PR TITLE
Make FFI classes GC.compact friendly

### DIFF
--- a/ext/ffi_c/compat.h
+++ b/ext/ffi_c/compat.h
@@ -79,4 +79,13 @@
 #  define RB_GC_GUARD(x) (x)
 #endif
 
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+#define ffi_compact_callback(x) .dcompact = (x),
+#define ffi_gc_location(x) x = rb_gc_location(x)
+#else
+#define rb_gc_mark_movable(x) rb_gc_mark(x)
+#define ffi_compact_callback(x)
+#define ffi_gc_location(x)
+#endif
+
 #endif /* RBFFI_COMPAT_H */

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -57,6 +57,8 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     append_ldflags "-Wl,--exclude-libs,ALL"
   end
 
+  have_func 'rb_gc_mark_movable' # since ruby-2.7
+
   # Some linux archs need explicit linking to pthread, see https://github.com/ffi/ffi/issues/893
   append_ldflags "-pthread"
 


### PR DESCRIPTION
This allows to relocate all FFI objects.

Also remove marking of `StructLayout->cache_row` in favour of clearing it at `GC.compact` only.