### PR TITLE
Remove old definitions in compat.h for Ruby 1.x

### DIFF
--- a/ext/ffi_c/compat.h
+++ b/ext/ffi_c/compat.h
@@ -32,26 +32,6 @@
 
 #include <ruby.h>
 
-#ifndef RARRAY_LEN
-#  define RARRAY_LEN(ary) RARRAY(ary)->len
-#endif
-
-#ifndef RARRAY_PTR
-#  define RARRAY_PTR(ary) RARRAY(ary)->ptr
-#endif
-
-#ifndef RSTRING_LEN
-#  define RSTRING_LEN(s) RSTRING(s)->len
-#endif
-
-#ifndef RSTRING_PTR
-#  define RSTRING_PTR(s) RSTRING(s)->ptr
-#endif
-
-#ifndef NUM2ULL
-#  define NUM2ULL(x) rb_num2ull((VALUE)x)
-#endif
-
 #ifndef roundup
 #  define roundup(x, y)   ((((x)+((y)-1))/(y))*(y))
 #endif
@@ -75,9 +55,6 @@
 #  define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
-#ifndef RB_GC_GUARD
-#  define RB_GC_GUARD(x) (x)
-#endif
 
 #ifdef HAVE_RB_GC_MARK_MOVABLE
 #define ffi_compact_callback(x) .dcompact = (x),


### PR DESCRIPTION
These definitions all exist in all recent versions of Ruby, so it's dead code that we can remove.