### PR TITLE
Remove use of RARRAY_PTR

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -150,7 +150,7 @@ memory_put_array_of_##name(VALUE self, VALUE offset, VALUE ary) \
     if (likely(count > 0)) checkWrite(memory); \
     checkBounds(memory, off, count * sizeof(type)); \
     for (i = 0; i < count; i++) { \
-        type tmp = (type) VAL(toNative(RARRAY_PTR(ary)[i]), swap); \
+        type tmp = (type) VAL(toNative(RARRAY_AREF(ary, i)), swap); \
         memcpy(memory->address + off + (i * sizeof(type)), &tmp, sizeof(tmp)); \
     } \
     return self; \

--- a/ext/ffi_c/Struct.c
+++ b/ext/ffi_c/Struct.c
@@ -132,7 +132,7 @@ struct_initialize(int argc, VALUE* argv, VALUE self)
 
     /* Call up into ruby code to adjust the layout */
     if (nargs > 1) {
-        VALUE rbLayout = rb_funcall2(CLASS_OF(self), id_layout, (int) RARRAY_LEN(rest), RARRAY_PTR(rest));
+        VALUE rbLayout = rb_apply(CLASS_OF(self), id_layout, rest);
         RB_OBJ_WRITE(self, &s->rbLayout, rbLayout);
     } else {
         RB_OBJ_WRITE(self, &s->rbLayout, struct_class_layout(klass));


### PR DESCRIPTION
RARRAY_PTR is bad for GC performance as it exposes the internal buffer of the array meaning that the array becomes write barrier unprotected.