### PR TITLE
Windows - Update LoadLibrary Error Message to include Error Code

### DIFF
--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -225,8 +225,16 @@ dl_open(const char* name, int flags)
 static void
 dl_error(char* buf, int size)
 {
-    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(),
-            0, buf, size, NULL);
+    // Get the last error code
+    DWORD error = GetLastError();
+
+    // Get the associated message
+    LPSTR message = NULL;
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER, 
+                   NULL, error, 0, (LPSTR)&message, 0, NULL);
+
+    // Update the passed in buffer
+    snprintf(buf, size, "Failed with error %d: %s", error, message);
 }
 #endif
 


### PR DESCRIPTION
On Windows FormatMessageA can return a NULL message - for example when trying to load a 32bit dll from a 64 bit program (garbage.so in the test suite). Since the passed in buffer contains junk data the resulting error message is made up of garbage characters which makes it impossible to know what the problem is.

This commit updates the message so that it always returns the error code (in this case 193) plus message, which makes it possible to debug the problem.