### PR TITLE
Free Allocated Buffer

### DIFF
--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -235,6 +235,9 @@ dl_error(char* buf, int size)
 
     // Update the passed in buffer
     snprintf(buf, size, "Failed with error %d: %s", error, message);
+
+    // Free the allocated message
+    LocalFree(message);
 }
 #endif
 


### PR DESCRIPTION
Free the message allocated by FormatMessageA (should have been included in the last commit).