### PR TITLE
MSVC Test Support

### DIFF
--- a/spec/ffi/fixtures/ClosureTest.c
+++ b/spec/ffi/fixtures/ClosureTest.c
@@ -16,10 +16,10 @@
 
 double testClosureVrDva(double d, ...) {
     va_list args;
-    double (*closure)(void);
+    typedef double (*closure_fun)(void);
 
     va_start(args, d);
-    closure = va_arg(args, double (*)(void));
+    closure_fun closure = va_arg(args, closure_fun);
     va_end(args);
 
     return d + closure();
@@ -27,12 +27,12 @@ double testClosureVrDva(double d, ...) {
 
 long testClosureVrILva(int i, long l, ...) {
     va_list args;
-    int (*cl1)(int);
-    long (*cl2)(long);
+    typedef int (*cl1_fun)(int);
+    typedef long (*cl2_fun)(long);
 
     va_start(args, l);
-    cl1 = va_arg(args, int (*)(int));
-    cl2 = va_arg(args, long (*)(long));
+    cl1_fun cl1 = va_arg(args, cl1_fun);
+    cl2_fun cl2 = va_arg(args, cl2_fun);
     va_end(args);
 
     return cl1(i) + cl2(l);

--- a/spec/ffi/fixtures/PipeHelperWindows.c
+++ b/spec/ffi/fixtures/PipeHelperWindows.c
@@ -16,7 +16,7 @@ int pipeHelperCreatePipe(FD_TYPE pipefd[2])
     sprintf( name, "\\\\.\\Pipe\\pipeHelper-%u-%i",
              (unsigned int)GetCurrentProcessId(), pipe_idx++ );
 
-    pipefd[0] = CreateNamedPipe( name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+    pipefd[0] = CreateNamedPipeA( name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
                          PIPE_TYPE_BYTE | PIPE_WAIT,
                          1,             // Number of pipes
                          5,         // Out buffer size
@@ -26,7 +26,7 @@ int pipeHelperCreatePipe(FD_TYPE pipefd[2])
     if(pipefd[0] == INVALID_HANDLE_VALUE)
         return -1;
 
-    pipefd[1] = CreateFile( name, GENERIC_WRITE, 0, NULL,
+    pipefd[1] = CreateFileA( name, GENERIC_WRITE, 0, NULL,
                         OPEN_EXISTING,
                         FILE_ATTRIBUTE_NORMAL,
                         NULL);

--- a/spec/ffi/fixtures/PointerTest.c
+++ b/spec/ffi/fixtures/PointerTest.c
@@ -5,7 +5,9 @@
  */
 
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <sys/param.h>
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This MR includes several small changes that enable MSVC 2022 to compile the libtest library in the spec/fixtures directory. With these changes, all tests pass on MSVC.

Note that the compile.rb file on Windows only works with mingw, so it would have to change to support MSVC. I assume that isn't important,  but if we wanted to go down that route at some point we could either:

*  add a Makefile for nmake like mkmf does
*  or likely better, and way more modern, add a simple CMakelists.text file and use cmake