### PR TITLE
Remove no longer used StructField.get and .put

### DIFF
--- a/ext/ffi_c/Struct.c
+++ b/ext/ffi_c/Struct.c
@@ -356,10 +356,7 @@ struct_aref(VALUE self, VALUE fieldName)
     s = struct_validate(self);
 
     f = struct_field(s, fieldName);
-    if (f->get != NULL) {
-        return (*f->get)(f, s);
-
-    } else if (f->memoryOp != NULL) {
+    if (f->memoryOp != NULL) {
         return (*f->memoryOp->get)(s->pointer, f->offset);
 
     } else {
@@ -385,10 +382,7 @@ struct_aset(VALUE self, VALUE fieldName, VALUE value)
     s = struct_validate(self);
 
     f = struct_field(s, fieldName);
-    if (f->put != NULL) {
-        (*f->put)(f, s, value);
-
-    } else if (f->memoryOp != NULL) {
+    if (f->memoryOp != NULL) {
 
         (*f->memoryOp->put)(s->pointer, f->offset, value);
 

--- a/ext/ffi_c/Struct.h
+++ b/ext/ffi_c/Struct.h
@@ -59,9 +59,6 @@ extern "C" {
         VALUE rbType;
         VALUE rbName;
 
-        VALUE (*get)(StructField* field, Struct* s);
-        void (*put)(StructField* field, Struct* s, VALUE value);
-
         MemoryOp* memoryOp;
     };
 


### PR DESCRIPTION
It was introduced in commit 9d68c7f87ad7c869ee1ce3139269525af70e5df4 but moved to ruby code in commit 3f96bbb61b2f17ba9761a1d02745101a60cd26e1 . These fields are a leftover from the commit.