### PR TITLE
closes #155

### DIFF
--- a/lib/ffi/dynamic_library.rb
+++ b/lib/ffi/dynamic_library.rb
@@ -34,6 +34,11 @@ module FFI
     if FFI::Platform::ARCH == 'aarch64' && FFI::Platform.mac?
       SEARCH_PATH << '/opt/homebrew/lib'
     end
+    if FFI::Platform.mac?
+      from_env_vars = ENV.fetch('DYLD_LIBRARY_PATH', '').split(':')
+      from_env_vars += ENV.fetch('DYLD_FALLBACK_LIBRARY_PATH', '').split(':')
+      SEARCH_PATH.unshift(*from_env_vars)
+    end
 
     SEARCH_PATH_MESSAGE = "Searched in <system library path>, #{SEARCH_PATH.join(', ')}".freeze
 


### PR DESCRIPTION
Here's a similar fix for the ~ 1.15.x series for posterity.

```ruby
                  # TODO better library lookup logic
                  unless libname.start_with?("/") || FFI::Platform.windows?
+                   dirs  = ENV.fetch('DYLD_LIBRARY_PATH',          '').split(':').map { |part| part+'/' }
+                   dirs += ENV.fetch('DYLD_FALLBACK_LIBRARY_PATH', '').split(':').map { |part| part+'/' }
+                   dirs += ['/usr/lib/','/usr/local/lib/','/opt/local/lib/', '/opt/homebrew/lib/']
+                   path = dirs.find do |pth|
-                   path = ['/usr/lib/','/usr/local/lib/','/opt/local/lib/', '/opt/homebrew/lib/'].find do |pth|
                      File.exist?(pth + libname)
                    end
```