### PR TITLE
Update fat binary gems for Windows to ruby-3.2 and update libffi

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,8 @@ task 'gem:java' => 'java:gem'
 FfiGemHelper.install_tasks
 # Register windows gems to be pushed to rubygems.org
 Bundler::GemHelper.instance.cross_platforms = %w[x86-mingw32 x64-mingw-ucrt x64-mingw32]
+# These platforms are not yet enabled, since there are issues on musl-based distors (alpine-linux):
+# + %w[x86-linux x86_64-linux arm-linux aarch64-linux x86_64-darwin arm64-darwin]
 
 if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   require 'rake/extensiontask'
@@ -120,8 +122,8 @@ namespace "gem" do
     desc "Build the native gem for #{plat}"
     task plat => ['prepare', 'build'] do
       RakeCompilerDock.sh <<-EOT, platform: plat
-        sudo apt-get update &&
-        sudo apt-get install -y libltdl-dev && bundle --local &&
+        #{ "sudo apt-get update && sudo apt-get install -y libltdl-dev &&" if plat !~ /linux/ }
+        bundle --local &&
         rake native:#{plat} pkg/#{gem_spec.full_name}-#{plat}.gem MAKE='nice make -j`nproc`' RUBY_CC_VERSION=${RUBY_CC_VERSION/:2.2.2/}
       EOT
     end

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -75,7 +75,13 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
 
   unless system_libffi
     File.open("Makefile", "a") do |mf|
-      mf.puts "LIBFFI_HOST=--host=#{RbConfig::CONFIG['host_alias']}" if RbConfig::CONFIG.has_key?("host_alias")
+      if RbConfig::CONFIG['host_alias'] == "i386-w64-mingw32"
+        host = "i686-w64-mingw32" # Work around host name without matching compiler name in rake-compiler-dock-1.3.0 on platform x86-mingw32
+      elsif RbConfig::CONFIG.has_key?("host_alias")
+        host = RbConfig::CONFIG['host_alias']
+      end
+      mf.puts "LIBFFI_HOST=--host=#{host}" if host
+
       if RbConfig::CONFIG['host_os'] =~ /darwin/i
         if RbConfig::CONFIG['host'] =~ /arm|aarch64/i
           mf.puts "LIBFFI_HOST=--host=aarch64-apple-#{RbConfig::CONFIG['host_os']}"

--- a/ext/ffi_c/libffi.bsd.mk
+++ b/ext/ffi_c/libffi.bsd.mk
@@ -18,7 +18,7 @@ INCFLAGS := -I${LIBFFI_BUILD_DIR}/include -I${INCFLAGS}
 
 LIBFFI = ${LIBFFI_BUILD_DIR}/.libs/libffi_convenience.a
 LIBFFI_AUTOGEN = ${LIBFFI_SRC_DIR}/autogen.sh
-LIBFFI_CONFIGURE = ${LIBFFI_SRC_DIR}/configure --disable-static \
+LIBFFI_CONFIGURE = ${LIBFFI_SRC_DIR}/configure --disable-shared --enable-static \
 	--with-pic=yes --disable-dependency-tracking --disable-docs
 
 $(OBJS):	${LIBFFI}

--- a/ext/ffi_c/libffi.darwin.mk
+++ b/ext/ffi_c/libffi.darwin.mk
@@ -37,7 +37,7 @@ $(LIBFFI):
 		echo "Configuring libffi"; \
 		cd "$(LIBFFI_BUILD_DIR)" && \
 		/usr/bin/env CC="$(CC)" LD="$(LD)" CFLAGS="$(LIBFFI_CFLAGS)" GREP_OPTIONS="" \
-		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) > /dev/null; \
+		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) --disable-shared --enable-static > /dev/null; \
 	fi
 	cd "$(LIBFFI_BUILD_DIR)" && $(MAKE)
 
@@ -56,7 +56,7 @@ build_ffi = \
 	    echo "Configuring libffi for $(1)"; \
 	    cd "$(BUILD_DIR)"/libffi-$(1) && \
 	      env CC="$(CCACHE) $(CC)" CFLAGS="-arch $(1) $(LIBFFI_CFLAGS)" LDFLAGS="-arch $(1)" \
-		$(LIBFFI_CONFIGURE) --host=$(1)-apple-darwin > /dev/null; \
+		$(LIBFFI_CONFIGURE) --host=$(1)-apple-darwin --disable-shared --enable-static > /dev/null; \
 	fi); \
 	$(MAKE) -C "$(BUILD_DIR)"/libffi-$(1)
 

--- a/ext/ffi_c/libffi.gnu.mk
+++ b/ext/ffi_c/libffi.gnu.mk
@@ -21,7 +21,7 @@ endif
 
 LIBFFI = "$(LIBFFI_BUILD_DIR)"/.libs/libffi_convenience.a
 LIBFFI_AUTOGEN = ${LIBFFI_SRC_DIR}/autogen.sh
-LIBFFI_CONFIGURE = "$(LIBFFI_SRC_DIR)"/configure --disable-static \
+LIBFFI_CONFIGURE = "$(LIBFFI_SRC_DIR)"/configure --disable-shared --enable-static \
 	--with-pic=yes --disable-dependency-tracking --disable-docs
 
 $(OBJS):	$(LIBFFI)


### PR DESCRIPTION
And allow to build binary gems for other platforms as well. Unfortunately there are issues on musl-based distros, so they are not yet enabled.