### PR TITLE
Add --enable-debug to extconf.rb which is called by 'rake compile'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,6 +100,8 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
     ext.cross_compiling do |spec|
       spec.files.reject! { |path| File.fnmatch?('ext/*', path) }
     end
+    # Enable debug info for 'rake compile' but not for 'gem install'
+    ext.config_options << "--enable-debug"
 
   end
 else

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -35,8 +35,8 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   # solaris 10 needs -c99 for <stdbool.h>
   $CFLAGS << " -g -std=c99" if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.11)/
   if enable_config("debug")
-    $CPPFLAGS += " -ggdb"
-    $LDFLAGS += " -ggdb"
+    $CPPFLAGS += " #{RbConfig::CONFIG["debugflags"]}"
+    $LDFLAGS += " #{RbConfig::CONFIG["debugflags"]}"
   end
 
   # Check whether we use system libffi
@@ -80,7 +80,7 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   unless system_libffi
     File.open("Makefile", "a") do |mf|
       if enable_config("debug")
-        mf.puts "LIBFFI_DEBUG=--enable-debug CPPFLAGS='-ggdb' LDFLAGS='-ggdb'"
+        mf.puts "LIBFFI_DEBUG=--enable-debug CPPFLAGS='#{RbConfig::CONFIG["debugflags"]}' LDFLAGS='#{RbConfig::CONFIG["debugflags"]}'"
       end
 
       if RbConfig::CONFIG['host_alias'] == "i386-w64-mingw32"

--- a/ext/ffi_c/extconf.rb
+++ b/ext/ffi_c/extconf.rb
@@ -34,6 +34,10 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
   $CFLAGS.gsub!(/[\s+]-std=[^\s]+/, '')
   # solaris 10 needs -c99 for <stdbool.h>
   $CFLAGS << " -g -std=c99" if RbConfig::CONFIG['host_os'] =~ /solaris(!?2\.11)/
+  if enable_config("debug")
+    $CPPFLAGS += " -ggdb"
+    $LDFLAGS += " -ggdb"
+  end
 
   # Check whether we use system libffi
   system_libffi = enable_config('system-libffi', :try)
@@ -75,6 +79,10 @@ if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'rbx'
 
   unless system_libffi
     File.open("Makefile", "a") do |mf|
+      if enable_config("debug")
+        mf.puts "LIBFFI_DEBUG=--enable-debug CPPFLAGS='-ggdb' LDFLAGS='-ggdb'"
+      end
+
       if RbConfig::CONFIG['host_alias'] == "i386-w64-mingw32"
         host = "i686-w64-mingw32" # Work around host name without matching compiler name in rake-compiler-dock-1.3.0 on platform x86-mingw32
       elsif RbConfig::CONFIG.has_key?("host_alias")

--- a/ext/ffi_c/libffi.bsd.mk
+++ b/ext/ffi_c/libffi.bsd.mk
@@ -19,7 +19,7 @@ INCFLAGS := -I${LIBFFI_BUILD_DIR}/include -I${INCFLAGS}
 LIBFFI = ${LIBFFI_BUILD_DIR}/.libs/libffi_convenience.a
 LIBFFI_AUTOGEN = ${LIBFFI_SRC_DIR}/autogen.sh
 LIBFFI_CONFIGURE = ${LIBFFI_SRC_DIR}/configure --disable-shared --enable-static \
-	--with-pic=yes --disable-dependency-tracking --disable-docs
+	--with-pic=yes --disable-dependency-tracking --disable-docs $(LIBFFI_DEBUG)
 
 $(OBJS):	${LIBFFI}
 

--- a/ext/ffi_c/libffi.darwin.mk
+++ b/ext/ffi_c/libffi.darwin.mk
@@ -37,7 +37,7 @@ $(LIBFFI):
 		echo "Configuring libffi"; \
 		cd "$(LIBFFI_BUILD_DIR)" && \
 		/usr/bin/env CC="$(CC)" LD="$(LD)" CFLAGS="$(LIBFFI_CFLAGS)" GREP_OPTIONS="" \
-		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) --disable-shared --enable-static > /dev/null; \
+		/bin/sh $(LIBFFI_CONFIGURE) $(LIBFFI_HOST) > /dev/null; \
 	fi
 	cd "$(LIBFFI_BUILD_DIR)" && $(MAKE)
 
@@ -56,7 +56,7 @@ build_ffi = \
 	    echo "Configuring libffi for $(1)"; \
 	    cd "$(BUILD_DIR)"/libffi-$(1) && \
 	      env CC="$(CCACHE) $(CC)" CFLAGS="-arch $(1) $(LIBFFI_CFLAGS)" LDFLAGS="-arch $(1)" \
-		$(LIBFFI_CONFIGURE) --host=$(1)-apple-darwin --disable-shared --enable-static > /dev/null; \
+		$(LIBFFI_CONFIGURE) --host=$(1)-apple-darwin > /dev/null; \
 	fi); \
 	$(MAKE) -C "$(BUILD_DIR)"/libffi-$(1)
 

--- a/ext/ffi_c/libffi.gnu.mk
+++ b/ext/ffi_c/libffi.gnu.mk
@@ -22,7 +22,7 @@ endif
 LIBFFI = "$(LIBFFI_BUILD_DIR)"/.libs/libffi_convenience.a
 LIBFFI_AUTOGEN = ${LIBFFI_SRC_DIR}/autogen.sh
 LIBFFI_CONFIGURE = "$(LIBFFI_SRC_DIR)"/configure --disable-shared --enable-static \
-	--with-pic=yes --disable-dependency-tracking --disable-docs
+	--with-pic=yes --disable-dependency-tracking --disable-docs $(LIBFFI_DEBUG)
 
 $(OBJS):	$(LIBFFI)
 


### PR DESCRIPTION
It enables debug symbols and libffi assertions.
By default it is enabled for in-tree builds but `gem install` is not affected.