### PR TITLE
Avoid trying to store new DataConverter type in frozen TypeDefs hash

### DIFF
--- a/lib/ffi/types.rb
+++ b/lib/ffi/types.rb
@@ -87,7 +87,8 @@ module FFI
       TypeDefs[name]
 
     elsif name.is_a?(DataConverter)
-      (type_map || TypeDefs)[name] = Type::Mapped.new(name)
+      tm = (type_map || custom_typedefs)
+      tm[name] = Type::Mapped.new(name)
     else
       raise TypeError, "unable to resolve type '#{name}'"
     end

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -215,6 +215,19 @@ module StructSpecsStructTests
       expect(s[:b]).to eq(0xdeadcafebabe)
     end
 
+    it "Can use DataConverter in an embedded array" do
+      class Blub #< FFI::Struct
+        extend FFI::DataConverter
+        native_type FFI::Type::INT
+      end
+
+      class Zork < FFI::Struct
+        layout :c, [Blub, 2], 2
+      end
+      z = Zork.new
+      expect(z[:c].to_a).to eq [0, 0]
+    end
+
     it "Can use Struct subclass as parameter type" do
       expect(module StructParam
         extend FFI::Library


### PR DESCRIPTION
Fixes #1056.
