### PR TITLE
allow SEARCH_PATH to be extended with LD_LIBRARY_PATH and DYLD_LIBRAR…

### DIFF
--- a/lib/ffi/dynamic_library.rb
+++ b/lib/ffi/dynamic_library.rb
@@ -34,7 +34,9 @@ module FFI
     if FFI::Platform::ARCH == 'aarch64' && FFI::Platform.mac?
       SEARCH_PATH << '/opt/homebrew/lib'
     end
-
+    %w[LD_LIBRARY_PATH DYLD_LIBRARY_PATH].each do |custom_path|
+      SEARCH_PATH += ENV.fetch(custom_path,"").split(":")
+    end
     SEARCH_PATH_MESSAGE = "Searched in <system library path>, #{SEARCH_PATH.join(', ')}".freeze
 
     def self.load_library(name, flags)


### PR DESCRIPTION
I'm hoping this might help address issues like https://github.com/ffi/ffi/issues/923.

Using Nix (on darwin) I often hit issues (particularly with libraries like vips that require ffi) where glib etc can't be found. By setting up one of the standard paths like LD_LIBRARY path or DYLD_LIBRARY_PATH I _should_ be able to move past this, however FFI only looks i a few standard places for libraries.   This patch should provide an easy way past this. 