### PR TITLE
Update `NativeType` doc

### DIFF
--- a/ext/ffi_c/Type.c
+++ b/ext/ffi_c/Type.c
@@ -333,10 +333,10 @@ rbffi_Type_Init(VALUE moduleFFI)
     classBuiltinType = rb_define_class_under(rbffi_TypeClass, "Builtin", rbffi_TypeClass);
     /*
      * Document-module: FFI::NativeType
-     * This module defines constants for native (C) types.
+     * This module defines constants for C native types.
      *
      * ==Native type constants
-     * Native types are defined by constants :
+     * Native types are defined by constants and aliases:
      * * INT8, SCHAR, CHAR
      * * UINT8, UCHAR
      * * INT16, SHORT, SSHORT
@@ -349,24 +349,25 @@ rbffi_Type_Init(VALUE moduleFFI)
      * * ULONG
      * * FLOAT32, FLOAT
      * * FLOAT64, DOUBLE
+     * * LONGDOUBLE (if the native platform has `long double`)
      * * POINTER
-     * * CALLBACK
-     * * FUNCTION
-     * * CHAR_ARRAY
      * * BOOL
-     * * STRING (immutable string, nul terminated)
-     * * STRUCT (struct-b-value param or result)
-     * * ARRAY (array type definition)
-     * * MAPPED (custom native type)
-     * For function return type only :
+     * * STRING (immutable string, null terminated)
+     * For function return type only:
      * * VOID
-     * For function argument type only :
+     * For function argument type only:
      * * BUFFER_IN
      * * BUFFER_OUT
+     * * BUFFER_INOUT
      * * VARARGS (function takes a variable number of arguments)
      *
-     * All these constants are exported to {FFI} module prefixed with "TYPE_".
-     * They are objets from {FFI::Type::Builtin} class.
+     * They are objects of the class {FFI::Type::Builtin}.
+     * 
+     * Non-alias (the first name in each bullet point) constants are also exported to modules +FFI::NativeType+ and (prefixed with +TYPE_+) {FFI}.
+     * All constants and aliases above are exported to the {FFI::Type} class, as well as the following aliases:
+     * * Array ({FFI::ArrayType})
+     * * Function ({FFI::FunctionType})
+     * * Struct ({FFI::StructByValue})
      */
     moduleNativeType = rb_define_module_under(moduleFFI, "NativeType");
 


### PR DESCRIPTION
* Add missing `BUFFER_INOUT` and “missing” `LONGDOUBLE`
* Remove mentions of (legacy types?) `CALLBACK` and `CHAR_ARRAY` – they are not found in 1.16.3 even though chances are that they *are* supported by every computer
* Update `ARRAY`, `FUNCTION` and `STRUCT` to CamelCase and separate these class aliases from the `Type::Builtin` list
  * Remove `MAPPED` – [`Mapped` has its own doc](https://rubydoc.info/gems/ffi/FFI/Type/Mapped)
* Clarify that, while all constants are exported to `Type`, the aliases aren’t found in `FFI` and `NativeType`
  * This could rather be an oversight in the `A` macro
* Fix typos
  * Avoid writing `(C)`, which instead renders to `©` ([rendered docs on `rubydoc.info`](https://rubydoc.info/gems/ffi/1.16.3/FFI/NativeType))