### PR TITLE
Replace `Fixnum` by `Integer` and use `Integer` instead of `Numeric` for offsets and sizes

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -324,7 +324,7 @@ memory_clear(VALUE self)
 /*
  * call-seq: memory.size
  * Return memory size in bytes (alias: #total)
- * @return [Numeric]
+ * @return [Integer]
  */
 static VALUE
 memory_size(VALUE self)
@@ -340,7 +340,7 @@ memory_size(VALUE self)
  * call-seq: memory.get(type, offset)
  * Return data of given type contained in memory.
  * @param [Symbol, Type] type_name type of data to get
- * @param [Numeric] offset point in buffer to start from
+ * @param [Integer] offset point in buffer to start from
  * @return [Object]
  * @raise {ArgumentError} if type is not supported
  */
@@ -373,7 +373,7 @@ undefined_type: {
 /*
  * call-seq: memory.put(type, offset, value)
  * @param [Symbol, Type] type_name type of data to put
- * @param [Numeric] offset point in buffer to start from
+ * @param [Integer] offset point in buffer to start from
  * @return [nil]
  * @raise {ArgumentError} if type is not supported
  */
@@ -407,8 +407,8 @@ undefined_type: {
 /*
  * call-seq: memory.get_string(offset, length=nil)
  * Return string contained in memory.
- * @param [Numeric] offset point in buffer to start from
- * @param [Numeric] length string's length in bytes. If nil, a (memory size - offset) length string is returned).
+ * @param [Integer] offset point in buffer to start from
+ * @param [Integer] length string's length in bytes. If nil, a (memory size - offset) length string is returned).
  * @return [String]
  * @raise {IndexError} if +length+ is too great
  * @raise {NullPointerError} if memory not initialized
@@ -435,8 +435,8 @@ memory_get_string(int argc, VALUE* argv, VALUE self)
 /*
  * call-seq: memory.get_array_of_string(offset, count=nil)
  * Return an array of strings contained in memory.
- * @param [Numeric] offset point in memory to start from
- * @param [Numeric] count number of strings to get. If nil, return all strings
+ * @param [Integer] offset point in memory to start from
+ * @param [Integer] count number of strings to get. If nil, return all strings
  * @return [Array<String>]
  * @raise {IndexError} if +offset+ is too great
  * @raise {NullPointerError} if memory not initialized
@@ -485,7 +485,7 @@ memory_get_array_of_string(int argc, VALUE* argv, VALUE self)
  * call-seq: memory.read_array_of_string(count=nil)
  * Return an array of strings contained in memory. Same as:
  *  memory.get_array_of_string(0, count)
- * @param [Numeric] count number of strings to get. If nil, return all strings
+ * @param [Integer] count number of strings to get. If nil, return all strings
  * @return [Array<String>]
  */
 static VALUE
@@ -505,7 +505,7 @@ memory_read_array_of_string(int argc, VALUE* argv, VALUE self)
 
 /*
  * call-seq: memory.put_string(offset, str)
- * @param [Numeric] offset
+ * @param [Integer] offset
  * @param [String] str
  * @return [self]
  * @raise {SecurityError} when writing unsafe string to memory
@@ -535,8 +535,8 @@ memory_put_string(VALUE self, VALUE offset, VALUE str)
 /*
  * call-seq: memory.get_bytes(offset, length)
  * Return string contained in memory.
- * @param [Numeric] offset point in buffer to start from
- * @param [Numeric] length string's length in bytes.
+ * @param [Integer] offset point in buffer to start from
+ * @param [Integer] length string's length in bytes.
  * @return [String]
  * @raise {IndexError} if +length+ is too great
  * @raise {NullPointerError} if memory not initialized
@@ -559,10 +559,10 @@ memory_get_bytes(VALUE self, VALUE offset, VALUE length)
 /*
  * call-seq: memory.put_bytes(offset, str, index=0, length=nil)
  * Put a string in memory.
- * @param [Numeric] offset point in buffer to start from
+ * @param [Integer] offset point in buffer to start from
  * @param [String] str string to put to memory
- * @param [Numeric] index
- * @param [Numeric] length string's length in bytes. If nil, a (memory size - offset) length string is returned).
+ * @param [Integer] index
+ * @param [Integer] length string's length in bytes. If nil, a (memory size - offset) length string is returned).
  * @return [self]
  * @raise {IndexError} if +length+ is too great
  * @raise {NullPointerError} if memory not initialized
@@ -601,7 +601,7 @@ memory_put_bytes(int argc, VALUE* argv, VALUE self)
 
 /*
  * call-seq: memory.read_bytes(length)
- * @param [Numeric] length of string to return
+ * @param [Integer] length of string to return
  * @return [String]
  * equivalent to :
  *  memory.get_bytes(0, length)
@@ -615,8 +615,8 @@ memory_read_bytes(VALUE self, VALUE length)
 /*
  * call-seq: memory.write_bytes(str, index=0, length=nil)
  * @param [String] str string to put to memory
- * @param [Numeric] index
- * @param [Numeric] length string's length in bytes. If nil, a (memory size - offset) length string is returned).
+ * @param [Integer] index
+ * @param [Integer] length string's length in bytes. If nil, a (memory size - offset) length string is returned).
  * @return [self]
  * equivalent to :
  *  memory.put_bytes(0, str, index, length)
@@ -637,7 +637,7 @@ memory_write_bytes(int argc, VALUE* argv, VALUE self)
 
 /*
  * call-seq: memory.type_size
- * @return [Numeric] type size in bytes
+ * @return [Integer] type size in bytes
  * Get the memory's type size.
  */
 static VALUE
@@ -653,7 +653,7 @@ memory_type_size(VALUE self)
 /*
  * Document-method: []
  * call-seq: memory[idx]
- * @param [Numeric] idx index to access in memory
+ * @param [Integer] idx index to access in memory
  * @return
  * Memory read accessor.
  */
@@ -862,8 +862,8 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: put_float32
      * call-seq: memory.put_float32offset, value)
-     * @param [Numeric] offset
-     * @param [Numeric] value
+     * @param [Integer] offset
+     * @param [Integer] value
      * @return [self]
      * Put +value+ as a 32-bit float in memory at offset +offset+ (alias: #put_float).
      */
@@ -871,7 +871,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: get_float32
      * call-seq: memory.get_float32(offset)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @return [Float]
      * Get a 32-bit float from memory at offset +offset+ (alias: #get_float).
      */
@@ -881,7 +881,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: write_float
      * call-seq: memory.write_float(value)
-     * @param [Numeric] value
+     * @param [Integer] value
      * @return [self]
      * Write +value+ as a 32-bit float in memory.
      *
@@ -902,8 +902,8 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: put_array_of_float32
      * call-seq: memory.put_array_of_float32(offset, ary)
-     * @param [Numeric] offset
-     * @param [Array<Numeric>] ary
+     * @param [Integer] offset
+     * @param [Array<Integer>] ary
      * @return [self]
      * Put values from +ary+ as 32-bit floats in memory from offset +offset+ (alias: #put_array_of_float).
      */
@@ -911,8 +911,8 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: get_array_of_float32
      * call-seq: memory.get_array_of_float32(offset, length)
-     * @param [Numeric] offset
-     * @param [Numeric] length number of Float to get
+     * @param [Integer] offset
+     * @param [Integer] length number of Float to get
      * @return [Array<Float>]
      * Get 32-bit floats in memory from offset +offset+ (alias: #get_array_of_float).
      */
@@ -931,7 +931,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: read_array_of_float
      * call-seq: memory.read_array_of_float(length)
-     * @param [Numeric] length number of Float to read
+     * @param [Integer] length number of Float to read
      * @return [Array<Float>]
      * Read 32-bit floats from memory.
      *
@@ -944,7 +944,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: put_float64
      * call-seq: memory.put_float64(offset, value)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @param [Numeric] value
      * @return [self]
      * Put +value+ as a 64-bit float (double) in memory at offset +offset+ (alias: #put_double).
@@ -953,7 +953,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: get_float64
      * call-seq: memory.get_float64(offset)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @return [Float]
      * Get a 64-bit float (double) from memory at offset +offset+ (alias: #get_double).
      */
@@ -984,7 +984,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: put_array_of_float64
      * call-seq: memory.put_array_of_float64(offset, ary)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @param [Array<Numeric>] ary
      * @return [self]
      * Put values from +ary+ as 64-bit floats (doubles) in memory from offset +offset+ (alias: #put_array_of_double).
@@ -993,8 +993,8 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: get_array_of_float64
      * call-seq: memory.get_array_of_float64(offset, length)
-     * @param [Numeric] offset
-     * @param [Numeric] length number of Float to get
+     * @param [Integer] offset
+     * @param [Integer] length number of Float to get
      * @return [Array<Float>]
      * Get 64-bit floats (doubles) in memory from offset +offset+ (alias: #get_array_of_double).
      */
@@ -1013,7 +1013,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: read_array_of_double
      * call-seq: memory.read_array_of_double(length)
-     * @param [Numeric] length number of Float to read
+     * @param [Integer] length number of Float to read
      * @return [Array<Float>]
      * Read 64-bit floats (doubles) from memory.
      *
@@ -1026,7 +1026,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: put_pointer
      * call-seq: memory.put_pointer(offset, value)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @param [nil,Pointer, Integer, #to_ptr] value
      * @return [self]
      * Put +value+ in memory from +offset+..
@@ -1035,7 +1035,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: get_pointer
      * call-seq: memory.get_pointer(offset)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @return [Pointer]
      * Get a {Pointer} to the memory from +offset+.
      */
@@ -1064,7 +1064,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: put_array_of_pointer
      * call-seq: memory.put_array_of_pointer(offset, ary)
-     * @param [Numeric] offset
+     * @param [Integer] offset
      * @param [Array<#to_ptr>] ary
      * @return [self]
      * Put an array of {Pointer} into memory from +offset+.
@@ -1073,8 +1073,8 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: get_array_of_pointer
      * call-seq: memory.get_array_of_pointer(offset, length)
-     * @param [Numeric] offset
-     * @param [Numeric] length
+     * @param [Integer] offset
+     * @param [Integer] length
      * @return [Array<Pointer>]
      * Get an array of {Pointer} of length +length+ from +offset+.
      */
@@ -1093,7 +1093,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     /*
      * Document-method: read_array_of_pointer
      * call-seq: memory.read_array_of_pointer(length)
-     * @param [Numeric] length
+     * @param [Integer] length
      * @return [Array<Pointer>]
      * Read an array of {Pointer} of length +length+.
      *

--- a/ext/ffi_c/ArrayType.c
+++ b/ext/ffi_c/ArrayType.c
@@ -110,7 +110,7 @@ array_type_memsize(const void *data)
 /*
  * call-seq: initialize(component_type, length)
  * @param [Type] component_type
- * @param [Numeric] length
+ * @param [Integer] length
  * @return [self]
  * A new instance of ArrayType.
  */
@@ -140,7 +140,7 @@ array_type_initialize(VALUE self, VALUE rbComponentType, VALUE rbLength)
 
 /*
  * call-seq: length
- * @return [Numeric]
+ * @return [Integer]
  * Get array's length
  */
 static VALUE

--- a/ext/ffi_c/Buffer.c
+++ b/ext/ffi_c/Buffer.c
@@ -219,7 +219,7 @@ slice(VALUE self, long offset, long len)
 
 /*
  * call-seq: + offset
- * @param [Numeric] offset
+ * @param [Integer] offset
  * @return [Buffer] a new instance of Buffer pointing from offset until end of previous buffer.
  * Add a Buffer with an offset
  */
@@ -236,8 +236,8 @@ buffer_plus(VALUE self, VALUE rbOffset)
 
 /*
  * call-seq: slice(offset, length)
- * @param [Numeric] offset
- * @param [Numeric] length
+ * @param [Integer] offset
+ * @param [Integer] length
  * @return [Buffer] a new instance of Buffer
  * Slice an existing Buffer.
  */

--- a/ext/ffi_c/Buffer.c
+++ b/ext/ffi_c/Buffer.c
@@ -114,7 +114,7 @@ buffer_release(void *data)
 /*
  * call-seq: initialize(size, count=1, clear=false)
  * @param [Integer, Symbol, #size] Type or size in bytes of a buffer cell
- * @param [Fixnum] count number of cell in the Buffer
+ * @param [Integer] count number of cell in the Buffer
  * @param [Boolean] clear if true, set the buffer to all-zero
  * @return [self]
  * @raise {NoMemoryError} if failed to allocate memory for Buffer

--- a/ext/ffi_c/DynamicLibrary.c
+++ b/ext/ffi_c/DynamicLibrary.c
@@ -128,7 +128,7 @@ library_open(VALUE klass, VALUE libname, VALUE libflags)
 /*
  * call-seq: initialize(libname, libflags)
  * @param [String] libname name of library to open
- * @param [Fixnum] libflags flags for library to open
+ * @param [Integer] libflags flags for library to open
  * @return [FFI::DynamicLibrary]
  * @raise {LoadError} if +libname+ cannot be opened
  * A new DynamicLibrary instance.
@@ -232,7 +232,7 @@ dl_error(char* buf, int size)
 
     // Get the associated message
     LPSTR message = NULL;
-    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER, 
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER,
                    NULL, error, 0, (LPSTR)&message, 0, NULL);
 
     // Update the passed in buffer

--- a/ext/ffi_c/LastError.c
+++ b/ext/ffi_c/LastError.c
@@ -141,7 +141,7 @@ thread_data_get(void)
 
 /*
  * call-seq: error
- * @return [Numeric]
+ * @return [Integer]
  * Get +errno+ value.
  */
 static VALUE
@@ -153,7 +153,7 @@ get_last_error(VALUE self)
 #if defined(_WIN32) || defined(__CYGWIN__)
 /*
  * call-seq: winapi_error
- * @return [Numeric]
+ * @return [Integer]
  * Get +GetLastError()+ value. Only Windows or Cygwin.
  */
 static VALUE
@@ -166,7 +166,7 @@ get_last_winapi_error(VALUE self)
 
 /*
  * call-seq: error(error)
- * @param [Numeric] error
+ * @param [Integer] error
  * @return [nil]
  * Set +errno+ value.
  */
@@ -185,7 +185,7 @@ set_last_error(VALUE self, VALUE error)
 #if defined(_WIN32) || defined(__CYGWIN__)
 /*
  * call-seq: error(error)
- * @param [Numeric] error
+ * @param [Integer] error
  * @return [nil]
  * Set +GetLastError()+ value. Only on Windows and Cygwin.
  */

--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -80,7 +80,7 @@ memptr_allocate(VALUE klass)
 
 /*
  * call-seq: initialize(size, count=1, clear=true)
- * @param [Fixnum, Bignum, Symbol, FFI::Type] size size of a memory cell (in bytes, or type whom size will be used)
+ * @param [Integer, Bignum, Symbol, FFI::Type] size size of a memory cell (in bytes, or type whom size will be used)
  * @param [Numeric] count number of cells in memory
  * @param [Boolean] clear set memory to all-zero if +true+
  * @return [self]

--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -81,7 +81,7 @@ memptr_allocate(VALUE klass)
 /*
  * call-seq: initialize(size, count=1, clear=true)
  * @param [Integer, Bignum, Symbol, FFI::Type] size size of a memory cell (in bytes, or type whom size will be used)
- * @param [Numeric] count number of cells in memory
+ * @param [Integer] count number of cells in memory
  * @param [Boolean] clear set memory to all-zero if +true+
  * @return [self]
  * A new instance of FFI::MemoryPointer.

--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -229,7 +229,7 @@ slice(VALUE self, long offset, long size)
 /*
  * Document-method: +
  * call-seq: ptr + offset
- * @param [Numeric] offset
+ * @param [Integer] offset
  * @return [Pointer]
  * Return a new {Pointer} from an existing pointer and an +offset+.
  */
@@ -246,8 +246,8 @@ ptr_plus(VALUE self, VALUE offset)
 
 /*
  * call-seq: ptr.slice(offset, length)
- * @param [Numeric] offset
- * @param [Numeric] length
+ * @param [Integer] offset
+ * @param [Integer] length
  * @return [Pointer]
  * Return a new {Pointer} from an existing one. This pointer points on same contents
  * from +offset+ for a length +length+.
@@ -319,7 +319,7 @@ ptr_equals(VALUE self, VALUE other)
 
 /*
  * call-seq: ptr.address
- * @return [Numeric] pointer's base address
+ * @return [Integer] pointer's base address
  * Return +self+'s base address (alias: #to_i).
  */
 static VALUE

--- a/ext/ffi_c/Struct.c
+++ b/ext/ffi_c/Struct.c
@@ -616,7 +616,7 @@ inline_array_initialize(VALUE self, VALUE rbMemory, VALUE rbField)
 
 /*
  * call-seq: size
- * @return [Numeric]
+ * @return [Integer]
  * Get size
  */
 static VALUE
@@ -641,7 +641,7 @@ inline_array_offset(InlineArray* array, int index)
 
 /*
  * call-seq: [](index)
- * @param [Numeric] index
+ * @param [Integer] index
  * @return [Type, Struct]
  */
 static VALUE
@@ -676,7 +676,7 @@ inline_array_aref(VALUE self, VALUE rbIndex)
 
 /*
  * call-seq: []=(index, value)
- * @param [Numeric] index
+ * @param [Integer] index
  * @param [Type, Struct]
  * @return [value]
  */

--- a/ext/ffi_c/StructLayout.c
+++ b/ext/ffi_c/StructLayout.c
@@ -188,7 +188,7 @@ struct_field_initialize(int argc, VALUE* argv, VALUE self)
 
 /*
  * call-seq: offset
- * @return [Numeric]
+ * @return [Integer]
  * Get the field offset.
  */
 static VALUE
@@ -201,7 +201,7 @@ struct_field_offset(VALUE self)
 
 /*
  * call-seq: size
- * @return [Numeric]
+ * @return [Integer]
  * Get the field size.
  */
 static VALUE
@@ -214,7 +214,7 @@ struct_field_size(VALUE self)
 
 /*
  * call-seq: alignment
- * @return [Numeric]
+ * @return [Integer]
  * Get the field alignment.
  */
 static VALUE
@@ -474,8 +474,8 @@ struct_layout_allocate(VALUE klass)
 /*
  * call-seq: initialize(fields, size, align)
  * @param [Array<StructLayout::Field>] fields
- * @param [Numeric] size
- * @param [Numeric] align
+ * @param [Integer] size
+ * @param [Integer] align
  * @return [self]
  * A new StructLayout instance.
  */

--- a/ext/ffi_c/StructLayout.c
+++ b/ext/ffi_c/StructLayout.c
@@ -132,7 +132,7 @@ struct_field_memsize(const void *data)
 /*
  * call-seq: initialize(name, offset, type)
  * @param [String,Symbol] name
- * @param [Fixnum] offset
+ * @param [Integer] offset
  * @param [FFI::Type] type
  * @return [self]
  * A new FFI::StructLayout::Field instance.

--- a/ext/ffi_c/Type.c
+++ b/ext/ffi_c/Type.c
@@ -107,7 +107,7 @@ type_allocate(VALUE klass)
 /*
  * Document-method: initialize
  * call-seq: initialize(value)
- * @param [Fixnum,Type] value
+ * @param [Integer,Type] value
  * @return [self]
  */
 static VALUE
@@ -135,7 +135,7 @@ type_initialize(VALUE self, VALUE value)
 
 /*
  * call-seq: type.size
- * @return [Fixnum]
+ * @return [Integer]
  * Return type's size, in bytes.
  */
 static VALUE
@@ -150,7 +150,7 @@ type_size(VALUE self)
 
 /*
  * call-seq: type.alignment
- * @return [Fixnum]
+ * @return [Integer]
  * Get Type alignment.
  */
 static VALUE
@@ -362,7 +362,7 @@ rbffi_Type_Init(VALUE moduleFFI)
      * * VARARGS (function takes a variable number of arguments)
      *
      * They are objects of the class {FFI::Type::Builtin}.
-     * 
+     *
      * Non-alias (the first name in each bullet point) constants are also exported to modules +FFI::NativeType+ and (prefixed with +TYPE_+) {FFI}.
      * All constants and aliases above are exported to the {FFI::Type} class, as well as the following aliases:
      * * Array ({FFI::ArrayType})

--- a/lib/ffi/io.rb
+++ b/lib/ffi/io.rb
@@ -42,9 +42,9 @@ module FFI
 
     # @param [#read] io io to read from
     # @param [AbstractMemory] buf destination for data read from +io+
-    # @param [nil, Numeric] len maximul number of bytes to read from +io+. If +nil+,
+    # @param [nil, Integer] len maximul number of bytes to read from +io+. If +nil+,
     #  read until end of file.
-    # @return [Numeric] length really read, in bytes
+    # @return [Integer] length really read, in bytes
     #
     # A version of IO#read that reads data from an IO and put then into a native buffer.
     #

--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -135,7 +135,7 @@ module FFI
     #   ffi_lib_flags(:lazy, :local) # => 5
     #
     # @param [Symbol, …] flags (see {FlagsMap})
-    # @return [Fixnum] the new value
+    # @return [Integer] the new value
     def ffi_lib_flags(*flags)
       @ffi_lib_flags = flags.inject(0) { |result, f| result | FlagsMap[f] }
     end

--- a/lib/ffi/pointer.rb
+++ b/lib/ffi/pointer.rb
@@ -45,12 +45,12 @@ module FFI
     SIZE = Platform::ADDRESS_SIZE / 8 unless const_defined?(:SIZE)
 
     # Return the size of a pointer on the current platform, in bytes
-    # @return [Numeric]
+    # @return [Integer]
     def self.size
       SIZE
     end unless respond_to?(:size)
 
-    # @param [nil,Numeric] len length of string to return
+    # @param [nil,Integer] len length of string to return
     # @return [String]
     # Read pointer's contents as a string, or the first +len+ bytes of the
     # equivalent string if +len+ is not +nil+.
@@ -63,7 +63,7 @@ module FFI
       end
     end unless method_defined?(:read_string)
 
-    # @param [Numeric] len length of string to return
+    # @param [Integer] len length of string to return
     # @return [String]
     # Read the first +len+ bytes of pointer's contents as a string.
     #
@@ -83,7 +83,7 @@ module FFI
     end unless method_defined?(:read_string_to_null)
 
     # @param [String] str string to write
-    # @param [Numeric] len length of string to return
+    # @param [Integer] len length of string to return
     # @return [self]
     # Write +len+ first bytes of +str+ in pointer's contents.
     #
@@ -94,7 +94,7 @@ module FFI
     end unless method_defined?(:write_string_length)
 
     # @param [String] str string to write
-    # @param [Numeric] len length of string to return
+    # @param [Integer] len length of string to return
     # @return [self]
     # Write +str+ in pointer's contents, or first +len+ bytes if
     # +len+ is not +nil+.
@@ -106,7 +106,7 @@ module FFI
 
     # @param [Type] type type of data to read from pointer's contents
     # @param [Symbol] reader method to send to +self+ to read +type+
-    # @param [Numeric] length
+    # @param [Integer] length
     # @return [Array]
     # Read an array of +type+ of length +length+.
     # @example

--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -46,7 +46,7 @@ module FFI
       self.class.size
     end
 
-    # @return [Fixnum] Struct alignment
+    # @return [Integer] Struct alignment
     def alignment
       self.class.alignment
     end

--- a/lib/ffi/struct.rb
+++ b/lib/ffi/struct.rb
@@ -41,7 +41,7 @@ module FFI
   class Struct
 
     # Get struct size
-    # @return [Numeric]
+    # @return [Integer]
     def size
       self.class.size
     end
@@ -87,13 +87,13 @@ module FFI
     end
 
     # Get struct size
-    # @return [Numeric]
+    # @return [Integer]
     def self.size
       defined?(@layout) ? @layout.size : defined?(@size) ? @size : 0
     end
 
     # set struct size
-    # @param [Numeric] size
+    # @param [Integer] size
     # @return [size]
     def self.size=(size)
       raise ArgumentError, "Size already set" if defined?(@size) || defined?(@layout)

--- a/lib/ffi/struct_layout.rb
+++ b/lib/ffi/struct_layout.rb
@@ -35,13 +35,13 @@ module FFI
 
   class StructLayout
 
-    # @return [Array<Array(Symbol, Numeric)>
+    # @return [Array<Array(Symbol, Integer)>
     # Get an array of tuples (field name, offset of the field).
     def offsets
       members.map { |m| [ m, self[m].offset ] }
     end
 
-    # @return [Numeric]
+    # @return [Integer]
     # Get the offset of a field.
     def offset_of(field_name)
       self[field_name].offset

--- a/lib/ffi/struct_layout_builder.rb
+++ b/lib/ffi/struct_layout_builder.rb
@@ -78,7 +78,7 @@ module FFI
     # @overload packed=(packed) Set alignment and packed attributes to
     #   +packed+.
     #
-    #   @param [Fixnum] packed
+    #   @param [Integer] packed
     #
     #   @return [packed]
     # @overload packed=(packed) Set packed attribute.

--- a/lib/ffi/struct_layout_builder.rb
+++ b/lib/ffi/struct_layout_builder.rb
@@ -46,13 +46,13 @@ module FFI
     end
 
     # Set size attribute with +size+ only if +size+ is greater than attribute value.
-    # @param [Numeric] size
+    # @param [Integer] size
     def size=(size)
       @size = size if size > @size
     end
 
     # Set alignment attribute with +align+ only if it is greater than attribute value.
-    # @param [Numeric] align
+    # @param [Integer] align
     def alignment=(align)
       @alignment = align if align > @alignment
       @min_alignment = align
@@ -116,7 +116,7 @@ module FFI
 
     # @param [String, Symbol] name name of the field
     # @param [Array, DataConverter, Struct, StructLayout::Field, Symbol, Type] type type of the field
-    # @param [Numeric, nil] offset
+    # @param [Integer, nil] offset
     # @return [self]
     # Add a field to the builder.
     # @note Setting +offset+ to +nil+ or +-1+ is equivalent to +0+.
@@ -154,7 +154,7 @@ module FFI
 
     # @param name (see #add)
     # @param type (see #add)
-    # @param [Numeric] count array length
+    # @param [Integer] count array length
     # @param offset (see #add)
     # @return (see #add)
     # Add an array as a field to the builder.
@@ -175,9 +175,9 @@ module FFI
 
     private
 
-    # @param [Numeric] offset
-    # @param [Numeric] align
-    # @return [Numeric]
+    # @param [Integer] offset
+    # @param [Integer] align
+    # @return [Integer]
     def align(offset, align)
       align + ((offset - 1) & ~(align - 1));
     end

--- a/lib/ffi/types.rb
+++ b/lib/ffi/types.rb
@@ -195,7 +195,7 @@ module FFI
   __typedef(StrPtrConverter, :strptr)
 
   # @param type +type+ is an instance of class accepted by {FFI.find_type}
-  # @return [Numeric]
+  # @return [Integer]
   # Get +type+ size, in bytes.
   def self.type_size(type)
     find_type(type).size

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -11,7 +11,7 @@ module TestLibrary
   CPU = case RbConfig::CONFIG['host_cpu'].downcase
     when /i[3456]86/
       # Darwin always reports i686, even when running in 64bit mode
-      if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Fixnum)
+      if RbConfig::CONFIG['host_os'] =~ /darwin/ && 0xfee1deadbeef.is_a?(Integer)
         "x86_64"
       else
         "i386"

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -56,7 +56,7 @@ describe "Pointer" do
     expect(PointerTestLib.ptr_ret_int32_t(ptr, 0)).to eq(magic)
   end
 
-  it "Fixnum cannot be used as a Pointer argument" do
+  it "Integer cannot be used as a Pointer argument" do
     expect { PointerTestLib.ptr_ret_int32_t(0, 0) }.to raise_error(ArgumentError)
   end
 


### PR DESCRIPTION
Fixes #1062 