### PR TITLE
Add bigdecimal to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
 
 group :development do
+  gem 'bigdecimal'
+  gem 'bundler', '>= 1.16', '< 3'
   gem 'rake', '~> 13.0'
   gem 'rake-compiler', '~> 1.1'
   gem 'rake-compiler-dock', '~> 1.0'
   gem 'rspec', '~> 3.0'
-  gem 'bundler', '>= 1.16', '< 3'
 end
 
 group :doc do


### PR DESCRIPTION
It is used in long_double_spec

Fixes the CI with ruby-head.