### PR TITLE
Avoid warning about undefined wariables

### DIFF
--- a/lib/ffi/function.rb
+++ b/lib/ffi/function.rb
@@ -55,7 +55,7 @@ module FFI
     # On CRuby it also ensures that it does not get garbage collected.
     module RegisterAttach
       def attach(mod, name)
-        funcs = mod.instance_variable_get("@ffi_functions")
+        funcs = mod.instance_variable_defined?("@ffi_functions") && mod.instance_variable_get("@ffi_functions")
         unless funcs
           funcs = {}
           mod.instance_variable_set("@ffi_functions", funcs)

--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -552,10 +552,10 @@ module FFI
     # @return [Hash< Symbol => ffi_type >]
     def attached_variables
       (
-        (@ffi_gsvars || {}).map do |name, gvar|
+        (defined?(@ffi_gsvars) ? @ffi_gsvars : {}).map do |name, gvar|
           [name, gvar.class]
         end +
-        (@ffi_gvars || {}).map do |name, gvar|
+        (defined?(@ffi_gvars) ? @ffi_gvars : {}).map do |name, gvar|
           [name, gvar.layout[:gvar].type]
         end
       ).to_h


### PR DESCRIPTION
warning: instance variable @ffi_functions not initialized