### PR TITLE
CI: Avoid rbs install on multiarch tests

### DIFF
--- a/spec/env/Dockerfile.alpine
+++ b/spec/env/Dockerfile.alpine
@@ -14,5 +14,6 @@ WORKDIR /build
 CMD ruby -v && \
   ruby -e "puts Gem::Platform.local.to_s" && \
   gem install --local *.gem --verbose --no-document && \
+  bundle config set --local without 'type_check' && \
   bundle install && \
   ruby -rffi -S rake test

--- a/spec/env/Dockerfile.centos
+++ b/spec/env/Dockerfile.centos
@@ -22,5 +22,6 @@ WORKDIR /build
 CMD ruby -v && \
   ruby -e "puts Gem::Platform.local.to_s" && \
   gem install --local *.gem --verbose --no-document && \
+  bundle config set --local without 'type_check' && \
   bundle install && \
   ruby -rffi -S rake test

--- a/spec/env/Dockerfile.debian
+++ b/spec/env/Dockerfile.debian
@@ -24,5 +24,6 @@ WORKDIR /build
 CMD  ruby -v && \
   ruby -e "puts Gem::Platform.local.to_s" && \
   gem install --local *.gem --verbose --no-document && \
+  bundle config set --local without 'type_check' && \
   bundle install && \
   ruby -rffi -S rake test


### PR DESCRIPTION
To avoid development tools there.