### PR TITLE
CI: Run jobs on master branch and pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,17 @@
 name: CI
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 3" # At 05:00 on Wednesday # https://crontab.guru/#0_5_*_*_3
+  push:
+    branches:
+      - master
+    tags:
+      - "*.*.*"
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - "*"
 permissions:
   contents: read
 


### PR DESCRIPTION
This is to avoid duplicated runs as soon as a pull request is opened. Please open a pull request to get the CI started!