### PR TITLE
Add FFI::AbstractMemory#read_array_of_string

### DIFF
--- a/ext/ffi_c/AbstractMemory.c
+++ b/ext/ffi_c/AbstractMemory.c
@@ -1109,6 +1109,7 @@ rbffi_AbstractMemory_Init(VALUE moduleFFI)
     rb_define_method(classMemory, "read_bytes", memory_read_bytes, 1);
     rb_define_method(classMemory, "write_bytes", memory_write_bytes, -1);
     rb_define_method(classMemory, "get_array_of_string", memory_get_array_of_string, -1);
+    rb_define_method(classMemory, "read_array_of_string", memory_read_array_of_string, -1);
 
     rb_define_method(classMemory, "get", memory_get, 2);
     rb_define_method(classMemory, "put", memory_put, 3);

--- a/sig/ffi/abstract_memory.rbs
+++ b/sig/ffi/abstract_memory.rbs
@@ -144,6 +144,7 @@ module FFI
     def read_array_of_float: (Integer length) -> Array[Float]
     def read_array_of_double: (Integer length) -> Array[Float]
     def read_array_of_pointer: (Integer length) -> Array[Pointer]
+    def read_array_of_string: (?Integer? count) -> Array[String?]
 
     def write_array_of_int8: (Array[int] ary) -> self
     def write_array_of_int16: (Array[int] ary) -> self

--- a/spec/ffi/string_spec.rb
+++ b/spec/ffi/string_spec.rb
@@ -48,6 +48,7 @@ describe "String tests" do
     ary.insert(3, nil)
     ptrary.write_array_of_pointer(ary)
     expect(ptrary.get_array_of_string(0)).to eq(["foo", "bar", "baz"])
+    expect(ptrary.read_array_of_string).to eq(["foo", "bar", "baz"])
   end
 
   it "reads an array of strings of the size specified, substituting nil when a pointer is NULL" do
@@ -61,6 +62,7 @@ describe "String tests" do
     ary.insert(2, nil)
     ptrary.write_array_of_pointer(ary)
     expect(ptrary.get_array_of_string(0, 4)).to eq(["foo", "bar", nil, "baz"])
+    expect(ptrary.read_array_of_string(4)).to eq(["foo", "bar", nil, "baz"])
   end
 
   it "reads an array of strings, taking a memory offset parameter" do
@@ -85,6 +87,7 @@ describe "String tests" do
     end
     ptrary.write_array_of_pointer(ary)
     expect { ptrary.get_array_of_string(0, 6) }.to raise_error(IndexError)
+    expect { ptrary.read_array_of_string(6) }.to raise_error(IndexError)
   end
 
   it "raises an IndexError when trying to read an array of strings using a negative offset" do


### PR DESCRIPTION
It was defined but not exposed to Ruby nor tested.

Fixes #1070