### PR TITLE
CI: Exclude Ractor tests on Windows-Ruby-3.3

### DIFF
--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -9,7 +9,7 @@ require 'objspace'
 
 RSpec.configure do |c|
   c.filter_run_excluding gc_dependent: true unless ENV['FFI_TEST_GC'] == 'true'
-  c.filter_run_excluding( :ractor ) unless defined?(Ractor) && RUBY_VERSION >= "3.1"
+  c.filter_run_excluding( :ractor ) unless defined?(Ractor) && RUBY_VERSION >= "3.1" && (RUBY_VERSION !~ /^3.3./ || RUBY_PLATFORM !~ /mingw/)
 end
 
 module TestLibrary


### PR DESCRIPTION
Ractor#take blocks sometimes infinitely on Ruby-3.3 on MINGW, but this seems unrelated to ffi.