### PR TITLE
Add Steep to check RBS files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,22 @@ jobs:
     - run: bundle exec rake test FFI_TEST_GC=true
     - run: bundle exec rake types_conf && git --no-pager diff
 
+  checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        ruby: [ 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, ruby-head ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+
+    - run: bundle install
+    - run: bundle exec steep check
+
   specs:
     # Run all specs on all ruby implementations
     # Use automatic libffi selection on MRI

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,6 @@ end
 group :type_check do
   if RUBY_VERSION >= "2.6" && %w[ ruby truffleruby ].include?(RUBY_ENGINE)
     gem 'rbs', '~> 3.0'
+    gem 'steep', '~> 1.6'
   end
 end

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,8 @@
+target :lib do
+  signature "sig"
+
+  check "lib"
+
+  # ignore whole of lib, to just validate RBS in sig
+  ignore "lib"
+end


### PR DESCRIPTION
This ensures RBS files are consistent and usable with Steep.

In addition, the CI check helps ensure that there is no regression on that front.

This is to help demonstrate and address #1107 