### PR TITLE
Restart async callback dispatcher thread after fork

### DIFF
--- a/spec/ffi/fixtures/FunctionTest.c
+++ b/spec/ffi/fixtures/FunctionTest.c
@@ -150,3 +150,14 @@ void __stdcall testStdcallManyParams(long *a1, char a2, short int a3, int a4, __
             struct StructUCDP a6, struct StructUCDP *a7, float a8, double a9) {
 }
 #endif
+
+static void (*testAsyncCallbackDelayedCb)(int);
+void testAsyncCallbackDelayedRegister(void (*fn)(int))
+{
+  testAsyncCallbackDelayedCb = fn;
+}
+
+void testAsyncCallbackDelayedTrigger(int value)
+{
+  testAsyncCallback(testAsyncCallbackDelayedCb, value);
+}


### PR DESCRIPTION
If we don't do this, callbacks registered before fork will never actually fire after forking, and just hang forever.

We explicitly re-initialize the entire context (including re-initializing the mutexes and clearing out the list of callbacks), because:

* If a thread in the parent was in the process of calling a callback when we fork, the mutex would otherwise be "stuck on"
* I don't think we _want_ to actually execute any pending callbacks from other threads in the child process, so clearing the list makes sense anyway.

Fixes: https://github.com/ffi/ffi/issues/1114