### PR TITLE
Gemfile: depend on fiddle to avoid a Ruby warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 group :development do
   gem 'bigdecimal' # necessary on ruby-3.3+
   gem 'bundler', '>= 1.16', '< 3'
+  gem 'fiddle', platforms: %i[mri windows] # necessary on ruby-3.5+
   gem 'rake', '~> 13.0'
   gem 'rake-compiler', '~> 1.1'
   gem 'rake-compiler-dock', '~> 1.0.pre'

--- a/spec/env/Dockerfile.alpine
+++ b/spec/env/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG from_image
 FROM ${from_image}
 
 RUN uname -a
-RUN apk add ruby ruby-etc ruby-rake ruby-dev git gcc make musl-dev gcompat
+RUN apk add ruby ruby-etc ruby-rake ruby-dev git gcc make musl-dev gcompat libffi-dev
 
 RUN ruby --version
 RUN ruby -e 'puts File.read("/proc/#{Process.pid}/maps")'

--- a/spec/env/Dockerfile.centos
+++ b/spec/env/Dockerfile.centos
@@ -8,6 +8,7 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 RUN yum install -y ruby-devel git gcc make redhat-rpm-config
+RUN yum --enablerepo=powertools install -y libffi-devel
 
 RUN ruby --version
 RUN gem env

--- a/spec/env/Dockerfile.centos
+++ b/spec/env/Dockerfile.centos
@@ -7,8 +7,7 @@ RUN uname -a
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-RUN yum install -y ruby-devel git gcc make redhat-rpm-config
-RUN yum --enablerepo=powertools install -y libffi-devel
+RUN yum install -y ruby-devel git gcc make redhat-rpm-config libffi-devel
 
 RUN ruby --version
 RUN gem env

--- a/spec/env/Dockerfile.debian
+++ b/spec/env/Dockerfile.debian
@@ -11,7 +11,8 @@ RUN apt-get update -qq && \
   ruby-dev \
   git \
   gcc \
-  make
+  make \
+  libffi-dev
 
 RUN ruby --version
 RUN gem env


### PR DESCRIPTION
...since it will not be shipped with Ruby after Ruby 3.5.0.

## Details

I could see that this was a test-only dependency, so I added it to the "development" group of gems in the Gemfile.

https://github.com/search?q=repo%3Affi%2Fffi%20fiddle&type=code shows only hits in the spec directory.