### PR TITLE
Fix warning about va_start parameter in libtest raised by clang

### DIFF
--- a/spec/ffi/fixtures/FunctionTest.c
+++ b/spec/ffi/fixtures/FunctionTest.c
@@ -64,7 +64,7 @@ void testBlockingClose(struct testBlockingData *self) {
 }
 
 static int sum_varargs(va_list args) {
-    char sum = 0;
+    int sum = 0;
     int arg;
     while ((arg = va_arg(args, int)) != 0) {
         sum += arg;
@@ -76,19 +76,19 @@ static int sum_varargs(va_list args) {
 /* Write c to pipe1 and return the value read from pipe2, or 0 if there’s
  * an error such as a timeout, or if c does not equal the sum of the
  * zero-terminated list of char arguments. */
-char testBlockingWRva(struct testBlockingData *self, char c, ...) {
+char testBlockingWRva(struct testBlockingData *self, int c, ...) {
     va_list args;
     va_start(args, c);
     if (sum_varargs(args) != c) {
         return 0;
     }
 
-    if( pipeHelperWriteChar(self->pipe1[1], c) != 1)
+    if( pipeHelperWriteChar(self->pipe1[1], (char)c) != 1)
         return 0;
     return pipeHelperReadChar(self->pipe2[0], 10);
 }
 
-char testBlockingRWva(struct testBlockingData *self, char c, ...) {
+char testBlockingRWva(struct testBlockingData *self, int c, ...) {
     va_list args;
     va_start(args, c);
     if (sum_varargs(args) != c) {
@@ -96,7 +96,7 @@ char testBlockingRWva(struct testBlockingData *self, char c, ...) {
     }
 
     char d = pipeHelperReadChar(self->pipe1[0], 10);
-    if( pipeHelperWriteChar(self->pipe2[1], c) != 1)
+    if( pipeHelperWriteChar(self->pipe2[1], (char)c) != 1)
         return 0;
     return d;
 }

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -18,8 +18,8 @@ describe "Function with variadic arguments" do
     callback :cbVrL, [:long], :long
 
     attach_function :testBlockingOpen, [ ], :pointer
-    attach_function :testBlockingRWva, [ :pointer, :char, :varargs ], :char, :blocking => true
-    attach_function :testBlockingWRva, [ :pointer, :char, :varargs ], :char, :blocking => true
+    attach_function :testBlockingRWva, [ :pointer, :int, :varargs ], :char, :blocking => true
+    attach_function :testBlockingWRva, [ :pointer, :int, :varargs ], :char, :blocking => true
     attach_function :testBlockingClose, [ :pointer ], :void
     attach_function :testCallbackVrDva, :testClosureVrDva, [ :double, :varargs ], :double
     attach_function :testCallbackVrILva, :testClosureVrILva, [ :int, :long, :varargs ], :long
@@ -44,7 +44,7 @@ describe "Function with variadic arguments" do
     skip 'this is not yet implemented on Truffleruby' if RUBY_ENGINE == 'truffleruby'
 
     fun = LibTest.attached_functions[:testBlockingWRva]
-    expect(fun.param_types).to eq([FFI::Type::POINTER, FFI::Type::CHAR, FFI::Type::VARARGS])
+    expect(fun.param_types).to eq([FFI::Type::POINTER, FFI::Type::INT, FFI::Type::VARARGS])
     expect(fun.return_type).to eq(FFI::Type::INT8)
   end
 


### PR DESCRIPTION
Kind of:
```
warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
    va_start(args, c);
                   ^
FunctionTest.c:79:59: note: parameter of type 'char' is declared here char testBlockingWRva(struct testBlockingData *self, char c, ...) {
                                                          ^
```