### PR TITLE
Ensure GC-ing closures before fork - 2nd attempt

### DIFF
--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -867,8 +867,10 @@ module CallbackInteropSpecs
     end
 
     after :all do
-      GC.start
-      expect(ObjectSpace.each_object(Fiddle::Closure) {}).to eq(0)
+      if Process.respond_to?(:fork)
+        GC.start
+        expect(ObjectSpace.each_object(Fiddle::Closure) {}).to eq(0)
+      end
     end
 
     def assert_callback_in_same_thread_called_once

--- a/spec/ffi/callback_spec.rb
+++ b/spec/ffi/callback_spec.rb
@@ -866,6 +866,11 @@ module CallbackInteropSpecs
       extern 'void testClosureVrV(void *fp)'
     end
 
+    after :all do
+      GC.start
+      expect(ObjectSpace.each_object(Fiddle::Closure) {}).to eq(0)
+    end
+
     def assert_callback_in_same_thread_called_once
       called = 0
       thread = nil


### PR DESCRIPTION
Fiddle::Closures can't be used before process is forked, otherwise test suite might crash with SELinux. This is similar treatment as is used in [Fiddle](https://github.com/ruby/fiddle/commit/1343ac7a9567665affc0e9f4bc9fd74cfd97a5fd).

Fixes #1120