### PR TITLE
Auto-convert Integer arguments to Pointer

### DIFF
--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -443,6 +443,10 @@ getPointer(VALUE value, int type)
 
         return StringValuePtr(value);
 
+    } else if (type == T_FIXNUM || type == T_BIGNUM) {
+
+        return (void*) (uintptr_t) NUM2ULL(value);
+
     } else if (type == T_NIL) {
 
         return NULL;

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -61,7 +61,7 @@ describe "Pointer" do
     magic = 0x12345678
     memory.put_int32(0, magic)
     adr = memory.address
-    expect(PointerTestLib.ptr_ret_int32_t(adr, 0))
+    expect(PointerTestLib.ptr_ret_int32_t(adr, 0)).to eq(magic)
   end
 
   it "String can be used as a Pointer argument" do

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -56,12 +56,12 @@ describe "Pointer" do
     expect(PointerTestLib.ptr_ret_int32_t(ptr, 0)).to eq(magic)
   end
 
-  it "Integer cannot be used as a Pointer argument" do
-    expect { PointerTestLib.ptr_ret_int32_t(0, 0) }.to raise_error(ArgumentError)
-  end
-
-  it "Bignum cannot be used as a Pointer argument" do
-    expect { PointerTestLib.ptr_ret_int32_t(0xfee1deadbeefcafebabe, 0) }.to raise_error(ArgumentError)
+  it "Integer can be used as a Pointer argument" do
+    memory = FFI::MemoryPointer.new :long_long
+    magic = 0x12345678
+    memory.put_int32(0, magic)
+    adr = memory.address
+    expect(PointerTestLib.ptr_ret_int32_t(adr, 0))
   end
 
   it "String can be used as a Pointer argument" do


### PR DESCRIPTION
Reverts https://github.com/ffi/ffi/commit/59b48a924b27c1361ac2095a7f4a6668ed20eed5 and https://github.com/ffi/ffi/commit/5104827f3f8ae91dabba5df0b11600dd96d1834c

Fiddle supports auto-converting anything that can be coerced into an integer to Pointer, however this doesn't work in JRuby using the ffi_backend.

One solution to this is to add the integer auto-convert logic into the ffi_backend (https://github.com/ruby/fiddle/pull/162)

Alternatively, we can add integer auto-convert back into FFI both here and in JRuby (https://github.com/jruby/jruby/pull/8423)

The next question is, if we do this, should it only be for `Integer` (as originally implemented), or should it also allow any integer-coercible value (as implemented by Fiddle)