### PR TITLE
Fix `FFI::DataConverter` non-generic usage

### DIFF
--- a/sig/ffi/library.rbs
+++ b/sig/ffi/library.rbs
@@ -33,7 +33,7 @@ module FFI
     def find_type: (ffi_lib_type t) -> Type
     def freeze: () -> void
     def function_names: (_ToS name, Array[Type | singleton(Struct)] arg_types) -> Array[String]
-    def typedef: [T < Type] (T old, Symbol | DataConverter add, ?untyped) -> T
+    def typedef: [T < Type, N, R, C] (T old, Symbol | DataConverter[N, R, C] add, ?untyped) -> T
                | (Symbol old, Symbol add, ?untyped) -> (Type | Enum)
                | [X < DataConverter[N, R, C], N, R, C] (X old, Symbol add, ?untyped) -> Type::Mapped[X, N, R, C]
                | (:enum old, Array[Symbol | Integer] add, ?untyped) -> Enum


### PR DESCRIPTION
Error was `RBS::InvalidTypeApplication`:

    Type `::FFI::DataConverter` is generic but used as a non generic type

at:

    def typedef: [T < Type] (T old, Symbol | DataConverter add, ?untyped) -> T

DataConverter being a generic type, it needs type arguments, which in turn needs these generic type arguments declared beforehand for `typedef`.

This is extracted from https://github.com/ffi/ffi/pull/1108 .

