### PR TITLE
Add msys2_mingw_dependencies for Windows Mingw

### DIFF
--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler', '~> 1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 2.14.1'
+
+  s.metadata['msys2_mingw_dependencies'] = 'libffi'
 end


### PR DESCRIPTION
This line will cause the correct Mingw package to automatically install for Windows users. You can see a similar example here:

https://github.com/ruby/psych/blob/master/psych.gemspec#L80