### PR TITLE
Fix making FFI::Function shareable for Ractor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
+  gem 'benchmark' # necessary on ruby-3.5+
   gem 'bigdecimal' # necessary on ruby-3.3+
   gem 'bundler', '>= 1.16', '< 3'
   gem 'fiddle', platforms: %i[mri windows] # necessary on ruby-3.5+

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -48,12 +48,14 @@ describe FFI::Function do
     expect(LibTest.testFunctionAdd(10, 10, function_add)).to eq(20)
   end
 
-  def adder(a, b)
-    a + b
+  module TestShareable
+    def self.call(a, b)
+      a + b
+    end
   end
 
   it "can be made shareable for Ractor", :ractor do
-    add = FFI::Function.new(:int, [:int, :int], &method(:adder))
+    add = FFI::Function.new(:int, [:int, :int], TestShareable)
     Ractor.make_shareable(add)
 
     res = Ractor.new(add) do |add2|


### PR DESCRIPTION
This was broken since ruby commit
  https://github.com/ruby/ruby/commit/d80f3a287c5c8d0404b6cb837db360cab320cde1

It shrinked shareability of Proc objects, so that we have to avoid a Proc here.