### PR TITLE
Use Ractor#value instead of deprecated #take

### DIFF
--- a/samples/hello_ractor.rb
+++ b/samples/hello_ractor.rb
@@ -1,5 +1,10 @@
 require 'ffi'
 
+class Ractor
+  # compat with Ruby-3.4 and older
+  alias value take unless method_defined? :value
+end
+
 module Foo
   extend FFI::Library
   ffi_lib FFI::Library::LIBC
@@ -8,4 +13,4 @@ module Foo
 end
 Ractor.new do
   Foo.cputs("Hello, World via libc puts using FFI in a Ractor")
-end.take
+end.value

--- a/samples/qsort_ractor.rb
+++ b/samples/qsort_ractor.rb
@@ -1,5 +1,10 @@
 require 'ffi'
 
+class Ractor
+  # compat with Ruby-3.4 and older
+  alias value take unless method_defined? :value
+end
+
 module LibC
   extend FFI::Library
   ffi_lib FFI::Library::LIBC
@@ -23,6 +28,6 @@ res = Ractor.new(p) do |p|
     i1 < i2 ? -1 : i1 > i2 ? 1 : 0
   end
   puts "After qsort #{p.get_array_of_int32(0, 3).join(', ')}"
-end.take
+end.value
 
 puts "After ractor termination #{p.get_array_of_int32(0, 3).join(', ')}"

--- a/spec/ffi/async_callback_spec.rb
+++ b/spec/ffi/async_callback_spec.rb
@@ -72,7 +72,7 @@ describe "async callback" do
       LibTest.testAsyncCallback(cb, 0x7fffffff)
 
       [v, correct_ractor, correct_thread]
-    end.take
+    end.value
 
     expect(res).to eq([0x7fffffff, true, true])
   end

--- a/spec/ffi/dynamic_library_spec.rb
+++ b/spec/ffi/dynamic_library_spec.rb
@@ -12,7 +12,7 @@ describe FFI::DynamicLibrary do
 
     res = Ractor.new(libtest) do |libtest2|
       libtest2.find_symbol("testClosureVrV").address
-    end.take
+    end.value
 
     expect( res ).to be > 0
   end
@@ -22,7 +22,7 @@ describe FFI::DynamicLibrary do
       libtest = FFI::DynamicLibrary.open(TestLibrary::PATH,
           FFI::DynamicLibrary::RTLD_LAZY | FFI::DynamicLibrary::RTLD_GLOBAL)
       libtest.find_symbol("testClosureVrV")
-    end.take
+    end.value
 
     expect(res.address).to be > 0
   end

--- a/spec/ffi/enum_spec.rb
+++ b/spec/ffi/enum_spec.rb
@@ -449,7 +449,7 @@ describe "All enums" do
         TestEnum4.enum_type(:enum_type6)[0x4242424242424242],
         TestEnum4.enum_value(:c3)
       ]
-    end.take
+    end.value
     expect( res ).to eq( [0, :c1, :c20, :c1, :c28, 2] )
   end
 end

--- a/spec/ffi/errno_spec.rb
+++ b/spec/ffi/errno_spec.rb
@@ -39,7 +39,7 @@ describe "FFI.errno" do
     res = Ractor.new do
       LibTest.setLastError(0x12345678)
       FFI.errno
-    end.take
+    end.value
     expect(res).to eq(0x12345678)
   end
 end

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -60,7 +60,7 @@ describe FFI::Function do
 
     res = Ractor.new(add) do |add2|
       LibTest.testFunctionAdd(10, 10, add2)
-    end.take
+    end.value
 
     expect( res ).to eq(20)
   end
@@ -69,7 +69,7 @@ describe FFI::Function do
     res = Ractor.new do
       function_add = FFI::Function.new(:int, [:int, :int]) { |a, b| a + b }
       LibTest.testFunctionAdd(10, 10, function_add)
-    end.take
+    end.value
 
     expect( res ).to eq(20)
   end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -30,7 +30,7 @@ describe "Library" do
     it "should be queryable in Ractor", :ractor do
       res = Ractor.new do
         TestEnumValueRactor.enum_value(:one)
-      end.take
+      end.value
 
       expect( res ).to eq(0)
     end
@@ -397,7 +397,7 @@ describe "Library" do
         FFI::CURRENT_PROCESS,
         FFI::USE_THIS_PROCESS_AS_LIBRARY,
       ]
-    end.take
+    end.value
 
     expect( res.size ).to be > 0
   end

--- a/spec/ffi/platform_spec.rb
+++ b/spec/ffi/platform_spec.rb
@@ -143,7 +143,7 @@ describe "FFI::Platform.unix?" do
         FFI::Platform::ARCH,
         FFI::Platform::OS,
       ]
-    end.take
+    end.value
 
     expect( res.size ).to be > 0
   end

--- a/spec/ffi/spec_helper.rb
+++ b/spec/ffi/spec_helper.rb
@@ -7,6 +7,13 @@ require_relative 'fixtures/compile'
 require 'timeout'
 require 'objspace'
 
+if defined? Ractor
+  class Ractor
+    # compat with Ruby-3.4 and older
+    alias value take unless method_defined? :value
+  end
+end
+
 RSpec.configure do |c|
   c.filter_run_excluding gc_dependent: true unless ENV['FFI_TEST_GC'] == 'true'
 

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -485,7 +485,7 @@ module StructSpecsStructTests
         add_proc = lambda { |a, b| a + b }
         s[:add] = add_proc
         CallbackMember.struct_call_add_cb(s, 40, 2)
-      end.take
+      end.value
 
       expect( res ).to eq(42)
     end
@@ -567,7 +567,7 @@ module StructSpecsStructTests
 
       res = Ractor.new(a) do |a2|
         a2[:a]
-      end.take
+      end.value
 
       expect( res ).to eq(-34)
     end
@@ -581,7 +581,7 @@ module StructSpecsStructTests
         s = TestStructRactor.new
         s[:i] = 0x14
         LibTest.ptr_ret_int32_t(s, 0)
-      end.take
+      end.value
 
       expect( res ).to eq(0x14)
     end

--- a/spec/ffi/variadic_spec.rb
+++ b/spec/ffi/variadic_spec.rb
@@ -119,7 +119,7 @@ describe "Function with variadic arguments" do
     res = Ractor.new do
       pr = proc { 42.0 }
       LibTest.testCallbackVrDva(3.0, :cbVrD, pr)
-    end.take
+    end.value
 
     expect(res).to be_within(0.0000001).of(45.0)
   end


### PR DESCRIPTION
Ractor#take was removed from ruby-3.5 since https://github.com/ruby/ruby/pull/13445