### PR TITLE
Mark callback dispatcher thread as fork safe for Puma

### DIFF
--- a/ext/ffi_c/Function.c
+++ b/ext/ffi_c/Function.c
@@ -237,6 +237,8 @@ async_cb_dispatcher_initialize(struct async_cb_dispatcher *ctx)
 
     /* Name thread, for better debugging */
     rb_funcall(ctx->thread, rb_intern("name="), 1, rb_str_new2("FFI Callback Dispatcher"));
+    /* Advise multi-threaded app servers to ignore this thread for the purposes of fork safety warnings */
+    rb_funcall(ctx->thread, rb_intern("thread_variable_set"), 2, ID2SYM(rb_intern("fork_safe")), Qtrue);
 }
 
 static struct async_cb_dispatcher *

--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -26,7 +26,9 @@ describe FFI::Function do
       skip 'this is MRI-specific' if RUBY_ENGINE == 'truffleruby' || RUBY_ENGINE == 'jruby'
       FFI::Function.new(:int, []) { 5 } # Trigger initialization
 
-      expect(Thread.list.map(&:name)).to include('FFI Callback Dispatcher')
+      thread = Thread.list.find { |t| t.name == 'FFI Callback Dispatcher' }
+      expect(thread).to_not be_nil
+      expect(thread.thread_variable_get(:fork_safe)).to be true
     end
   end
 


### PR DESCRIPTION
We're in the process of enabling Puma's `preload_app!` config at @buildkite. When auditing threads spawned during boot, Puma flagged this gem's callback dispatcher thread as potentially not `fork` safe. However, it appears to have been made `fork` safe in https://github.com/ffi/ffi/pull/1117.

This PR adds a `:fork_safe` thread variable that Puma uses to exclude threads from its safety reporting, so that anyone else auditing their threads this way won't see false positives from this gem.

Refs:
- How Puma uses the variable: https://github.com/puma/puma/blob/97c7d129a940c809fb379b3ecf314d39a18a332b/lib/puma/cluster.rb#L370-L379
- How Rails sets the variable: https://github.com/rails/rails/blob/8bf7a3d4d5760da094031681d354a4e148c2ded6/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb#L42-L44