### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/ffi.gemspec
+++ b/ffi.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
     s.metadata['wiki_uri'] = 'https://github.com/ffi/ffi/wiki'
     s.metadata['source_code_uri'] = 'https://github.com/ffi/ffi/'
     s.metadata['mailing_list_uri'] = 'http://groups.google.com/group/ruby-ffi'
+    s.metadata['rubygems_mfa_required'] = 'true'
   end
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f =~ /^(\.|bench|gen|libtest|nbproject|spec)/


### PR DESCRIPTION
As a popular gem (over 180 million total downloads), `ffi` implicitly requires that all privileged operations by any of the owners require OTP.

By explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and "VERSION PUBLISHED WITH MFA" in the sidebar at https://rubygems.org/gems/ffi

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/