### PR TITLE
Allow to stack `NATIVE_MAPPED` types

### DIFF
--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -111,7 +111,7 @@ rbffi_SetupCallParams(int argc, VALUE* argv, int paramCount, Type** paramTypes,
         int type;
 
 
-        if (unlikely(paramType->nativeType == NATIVE_MAPPED)) {
+        while (unlikely(paramType->nativeType == NATIVE_MAPPED)) {
             VALUE values[] = { argv[argidx], Qnil };
             argv[argidx] = rb_funcall2(((MappedType *) paramType)->rbConverter, id_to_native, 2, values);
             paramType = ((MappedType *) paramType)->type;


### PR DESCRIPTION
FFI allows to use `DataConverter`s that convert from another mapped value for return values.
However, on MRI it's not possible to use `DataConverter`s and other mapped types that return another mapped type from `to_native` as parameters:

<details>

<summary><code>native_converter.rb</code></summary>

```ruby
require 'ffi'

class S < FFI::Struct
  layout :field, :string

  def self.release(*); end
end

class SConv
  extend FFI::DataConverter
  native_type S.auto_ptr

  def self.from_native(value, context)
    raise 'from_native NULL' if value.to_ptr.null?

    value
  end

  def self.to_native(value, context)
    raise 'to_native NULL' if value.to_ptr.null?

    value
  end
end

module C
  extend FFI::Library
  ffi_lib 'c'

  attach_function :malloc, [:size_t], S.auto_ptr
  # First thing I thought of to get NULL
  attach_function :getenv, [:string], SConv
  attach_function :setenv, [:string, SConv, :int], :int
end

p C.malloc(S.size)
puts '---'
begin
  o C.getenv('')
rescue => e
  p e.message
end
puts '---'
begin
  p C.setenv('', S.new(FFI::Pointer.new(0)), 0)
rescue => e
  p e.message
end
puts '---'
begin
  # Won't crash because value is never accessed, EINVAL is returned because of the empty name
  p C.setenv('', S.new(FFI::Pointer.new(1)), 0)
rescue => e
  p e.message
end
```

</details>

```bash
$ mise exec ruby@3.3 -- ruby native_converter.rb                                                                                                                                                                                   
#<S:0x00007512cefef5a0>
---
"from_native NULL"
---
"to_native NULL"
---
"Invalid parameter type: 24"
```

but JRuby allows that

```bash
$ mise exec ruby@jruby-9.4.3.0 -- ruby native_converter.rb                                                                                                                                                                           
#<S:0x5bb7a59>
---
"from_native NULL"
---
"to_native NULL"
---
-1
```

With my fix it works on MRI as well:

```bash
$ bundle exec ruby native_converter.rb
#<S:0x000074e32a3d6d78>
---
"from_native NULL"
---
"to_native NULL"
---
-1
```