### PR TITLE
LLVM JIT gem integration

### DIFF
--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -468,29 +468,21 @@ rbffi_llvm_jit_value_to_pointer(VALUE value)
     return getPointer(value, TYPE(value));
 }
 
-VALUE
-rbffi_llvm_jit_pointer_to_value(void* ptr)
-{
-    return rbffi_Pointer_NewInstance(ptr);
-}
-
 static VALUE
-ffi_init_llvm_jit_pointer_handlers(VALUE self)
+ffi_init_llvm_jit_to_native_handlers(VALUE self)
 {
     static ID id_add_symbol = 0;
-    VALUE llvm_c, name;
+    VALUE llvm_c, fn_ptr;
 
     if (!id_add_symbol) id_add_symbol = rb_intern("add_symbol");
 
     llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
+    fn_ptr = rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_value_to_pointer);
 
-    name = rb_str_new_cstr("ffi_llvm_jit_value_to_pointer");
-    rb_funcall(llvm_c, id_add_symbol, 2, name,
-               rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_value_to_pointer));
-
-    name = rb_str_new_cstr("ffi_llvm_jit_pointer_to_value");
-    rb_funcall(llvm_c, id_add_symbol, 2, name,
-               rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_pointer_to_value));
+    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_pointer"),      fn_ptr);
+    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_in"),    fn_ptr);
+    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_out"),   fn_ptr);
+    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_inout"), fn_ptr);
 
     return Qnil;
 }
@@ -533,7 +525,7 @@ rbffi_Call_Init(VALUE moduleFFI)
     id_to_ptr = rb_intern("to_ptr");
     id_to_native = rb_intern("to_native");
     id_map_symbol = rb_intern("__map_symbol");
-    rb_define_private_method(rb_singleton_class(moduleFFI), "init_llvm_jit_pointer_handlers",
-                             ffi_init_llvm_jit_pointer_handlers, 0);
+    rb_define_private_method(rb_singleton_class(moduleFFI), "init_llvm_jit_to_native_handlers",
+                             ffi_init_llvm_jit_to_native_handlers, 0);
 }
 

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -484,6 +484,10 @@ ffi_init_llvm_jit_to_native_handlers(VALUE self)
     rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_out"),   fn_ptr);
     rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_inout"), fn_ptr);
 
+    // It's exported now, but let's register all deps here anyway
+    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_save_errno"),
+               rbffi_Pointer_NewInstance((void *)rbffi_save_errno));
+
     return Qnil;
 }
 

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -471,13 +471,13 @@ rbffi_llvm_jit_value_to_pointer(VALUE value)
 static VALUE
 ffi_init_llvm_jit_to_native_handlers(VALUE self)
 {
-    static ID id_add_symbol = 0;
+    ID id_add_symbol;
     VALUE llvm_c, fn_ptr;
 
-    if (!id_add_symbol) id_add_symbol = rb_intern("add_symbol");
+    id_add_symbol = rb_intern("add_symbol");
 
     llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
-    fn_ptr = rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_value_to_pointer);
+    fn_ptr = rbffi_Pointer_NewInstance((void *)rbffi_llvm_jit_value_to_pointer);
 
     rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_pointer"),      fn_ptr);
     rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_in"),    fn_ptr);

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -462,31 +462,27 @@ getPointer(VALUE value, int type)
     return NULL;
 }
 
-void*
-rbffi_llvm_jit_value_to_pointer(VALUE value)
+static void*
+rbffi_value_to_pointer(VALUE value)
 {
     return getPointer(value, TYPE(value));
 }
 
 static VALUE
-ffi_init_llvm_jit_to_native_handlers(VALUE self)
+rbffi_value_to_native_converters(VALUE self)
 {
-    ID id_add_symbol;
-    VALUE llvm_c, fn_ptr;
+    VALUE fn_ptr;
 
-    id_add_symbol = rb_intern("add_symbol");
+    fn_ptr = rbffi_Pointer_NewInstance((void *)rbffi_value_to_pointer);
 
-    llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
-    fn_ptr = rbffi_Pointer_NewInstance((void *)rbffi_llvm_jit_value_to_pointer);
-
-    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_pointer"),      fn_ptr);
-    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_in"),    fn_ptr);
-    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_out"),   fn_ptr);
-    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_value_to_buffer_inout"), fn_ptr);
+    rb_yield_values(2, rb_str_new_cstr("value_to_pointer"),      fn_ptr);
+    rb_yield_values(2, rb_str_new_cstr("value_to_buffer_in"),    fn_ptr);
+    rb_yield_values(2, rb_str_new_cstr("value_to_buffer_out"),   fn_ptr);
+    rb_yield_values(2, rb_str_new_cstr("value_to_buffer_inout"), fn_ptr);
 
     // It's exported now, but let's register all deps here anyway
-    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_save_errno"),
-               rbffi_Pointer_NewInstance((void *)rbffi_save_errno));
+    rb_yield_values(2, rb_str_new_cstr("save_errno"),
+                    rbffi_Pointer_NewInstance((void *)rbffi_save_errno));
 
     return Qnil;
 }
@@ -529,7 +525,7 @@ rbffi_Call_Init(VALUE moduleFFI)
     id_to_ptr = rb_intern("to_ptr");
     id_to_native = rb_intern("to_native");
     id_map_symbol = rb_intern("__map_symbol");
-    rb_define_private_method(rb_singleton_class(moduleFFI), "init_llvm_jit_to_native_handlers",
-                             ffi_init_llvm_jit_to_native_handlers, 0);
+    rb_define_private_method(rb_singleton_class(moduleFFI), "value_to_native_converters",
+                             rbffi_value_to_native_converters, 0);
 }
 

--- a/ext/ffi_c/Call.c
+++ b/ext/ffi_c/Call.c
@@ -462,6 +462,39 @@ getPointer(VALUE value, int type)
     return NULL;
 }
 
+void*
+rbffi_llvm_jit_value_to_pointer(VALUE value)
+{
+    return getPointer(value, TYPE(value));
+}
+
+VALUE
+rbffi_llvm_jit_pointer_to_value(void* ptr)
+{
+    return rbffi_Pointer_NewInstance(ptr);
+}
+
+static VALUE
+ffi_init_llvm_jit_pointer_handlers(VALUE self)
+{
+    static ID id_add_symbol = 0;
+    VALUE llvm_c, name;
+
+    if (!id_add_symbol) id_add_symbol = rb_intern("add_symbol");
+
+    llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
+
+    name = rb_str_new_cstr("ffi_llvm_jit_value_to_pointer");
+    rb_funcall(llvm_c, id_add_symbol, 2, name,
+               rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_value_to_pointer));
+
+    name = rb_str_new_cstr("ffi_llvm_jit_pointer_to_value");
+    rb_funcall(llvm_c, id_add_symbol, 2, name,
+               rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_pointer_to_value));
+
+    return Qnil;
+}
+
 Invoker
 rbffi_GetInvoker(FunctionType *fnInfo)
 {
@@ -500,5 +533,7 @@ rbffi_Call_Init(VALUE moduleFFI)
     id_to_ptr = rb_intern("to_ptr");
     id_to_native = rb_intern("to_native");
     id_map_symbol = rb_intern("__map_symbol");
+    rb_define_private_method(rb_singleton_class(moduleFFI), "init_llvm_jit_pointer_handlers",
+                             ffi_init_llvm_jit_pointer_handlers, 0);
 }
 

--- a/ext/ffi_c/Types.c
+++ b/ext/ffi_c/Types.c
@@ -43,24 +43,19 @@
 static ID id_from_native = 0;
 static ID id_initialize = 0;
 
-VALUE
-rbffi_llvm_jit_pointer_to_value(void* ptr)
-{
-    return rbffi_Pointer_NewInstance(ptr);
-}
-
 static VALUE
 ffi_init_llvm_jit_from_native_handlers(VALUE self)
 {
-    static ID id_add_symbol = 0;
+    ID id_add_symbol;
     VALUE llvm_c;
 
-    if (!id_add_symbol) id_add_symbol = rb_intern("add_symbol");
+    id_add_symbol = rb_intern("add_symbol");
 
     llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
 
+    // For now we don't need a separate rbffi_llvm_jit_pointer_to_value
     rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_pointer_to_value"),
-               rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_pointer_to_value));
+               rbffi_Pointer_NewInstance((void *)rbffi_Pointer_NewInstance));
 
     return Qnil;
 }

--- a/ext/ffi_c/Types.c
+++ b/ext/ffi_c/Types.c
@@ -43,24 +43,6 @@
 static ID id_from_native = 0;
 static ID id_initialize = 0;
 
-static VALUE
-ffi_init_llvm_jit_from_native_handlers(VALUE self)
-{
-    ID id_add_symbol;
-    VALUE llvm_c;
-
-    id_add_symbol = rb_intern("add_symbol");
-
-    llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
-
-    // For now we don't need a separate rbffi_llvm_jit_pointer_to_value
-    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_pointer_to_value"),
-               rbffi_Pointer_NewInstance((void *)rbffi_Pointer_NewInstance));
-
-    return Qnil;
-}
-
-
 VALUE
 rbffi_NativeValue_ToRuby(Type* type, VALUE rbType, const void* ptr)
 {
@@ -152,12 +134,22 @@ rbffi_NativeValue_ToRuby(Type* type, VALUE rbType, const void* ptr)
     }
 }
 
+static VALUE
+rbffi_native_to_value_converters(VALUE self)
+{
+    // For now we don't need a separate rbffi_pointer_to_value
+    rb_yield_values(2, rb_str_new_cstr("pointer_to_value"),
+                    rbffi_Pointer_NewInstance((void *)rbffi_Pointer_NewInstance));
+
+    return Qnil;
+}
+
 void
 rbffi_Types_Init(VALUE moduleFFI)
 {
     id_from_native = rb_intern("from_native");
     id_initialize = rb_intern("initialize");
-    rb_define_private_method(rb_singleton_class(moduleFFI), "init_llvm_jit_from_native_handlers",
-                             ffi_init_llvm_jit_from_native_handlers, 0);
+    rb_define_private_method(rb_singleton_class(moduleFFI), "native_to_value_converters",
+                             rbffi_native_to_value_converters, 0);
 }
 

--- a/ext/ffi_c/Types.c
+++ b/ext/ffi_c/Types.c
@@ -43,6 +43,28 @@
 static ID id_from_native = 0;
 static ID id_initialize = 0;
 
+VALUE
+rbffi_llvm_jit_pointer_to_value(void* ptr)
+{
+    return rbffi_Pointer_NewInstance(ptr);
+}
+
+static VALUE
+ffi_init_llvm_jit_from_native_handlers(VALUE self)
+{
+    static ID id_add_symbol = 0;
+    VALUE llvm_c;
+
+    if (!id_add_symbol) id_add_symbol = rb_intern("add_symbol");
+
+    llvm_c = rb_const_get(rb_const_get(rb_cObject, rb_intern("LLVM")), rb_intern("C"));
+
+    rb_funcall(llvm_c, id_add_symbol, 2, rb_str_new_cstr("ffi_llvm_jit_pointer_to_value"),
+               rbffi_Pointer_NewInstance((void *)(uintptr_t)(void *)rbffi_llvm_jit_pointer_to_value));
+
+    return Qnil;
+}
+
 
 VALUE
 rbffi_NativeValue_ToRuby(Type* type, VALUE rbType, const void* ptr)
@@ -140,5 +162,7 @@ rbffi_Types_Init(VALUE moduleFFI)
 {
     id_from_native = rb_intern("from_native");
     id_initialize = rb_intern("initialize");
+    rb_define_private_method(rb_singleton_class(moduleFFI), "init_llvm_jit_from_native_handlers",
+                             ffi_init_llvm_jit_from_native_handlers, 0);
 }
 

--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -91,9 +91,10 @@ module FFI
 
       lib_flags = defined?(@ffi_lib_flags) && @ffi_lib_flags
 
-      @ffi_libs = names.map do |name|
+      @ffi_libs ||= []
+      @ffi_libs.concat(names.map do |name|
         FFI::DynamicLibrary.send(:load_library, name, lib_flags)
-      end
+      end)
     end
 
     # Set the calling convention for {#attach_function} and {#callback}
@@ -175,48 +176,9 @@ module FFI
     #
     # @raise [FFI::NotFoundError] if +func+ cannot be found in the attached libraries (see {#ffi_lib})
     def attach_function(name, func, args, returns = nil, options = nil)
-      mname, a2, a3, a4, a5 = name, func, args, returns, options
-      cname, arg_types, ret_type, opts = (a4 && (a2.is_a?(String) || a2.is_a?(Symbol))) ? [ a2, a3, a4, a5 ] : [ mname.to_s, a2, a3, a4 ]
-
-      # Convert :foo to the native type
-      arg_types = arg_types.map { |e| find_type(e) }
-      options = {
-        :convention => ffi_convention,
-        :type_map => defined?(@ffi_typedefs) ? @ffi_typedefs : nil,
-        :blocking => defined?(@blocking) && @blocking,
-        :enums => defined?(@ffi_enums) ? @ffi_enums : nil,
-      }
-
-      @blocking = false
-      options.merge!(opts) if opts && opts.is_a?(Hash)
-
-      # Try to locate the function in any of the libraries
-      invokers = []
-      ffi_libraries.each do |lib|
-        if invokers.empty?
-          begin
-            function = nil
-            function_names(cname, arg_types).find do |fname|
-              function = lib.find_function(fname)
-            end
-            raise LoadError unless function
-
-            invokers << if arg_types[-1] == FFI::NativeType::VARARGS
-              VariadicInvoker.new(function, arg_types, find_type(ret_type), options)
-
-            else
-              Function.new(find_type(ret_type), arg_types, function, options)
-            end
-
-          rescue LoadError
-          end
-        end
-      end
-      invoker = invokers.compact.shift
-      raise FFI::NotFoundError.new(cname.to_s, ffi_libraries.map { |lib| lib.name }) unless invoker
-
-      invoker.attach(self, mname.to_s)
-      invoker
+      mname, cname, arg_types, ret_type, options = convert_attach_function_params(name, func, args, returns, options)
+      function_handle = find_function_handle(cname, arg_types)
+      attach_function_handle(function_handle, mname, arg_types, ret_type, options)
     end
 
     # @param [#to_s] name function name
@@ -416,6 +378,57 @@ module FFI
     end
 
     private
+
+    def convert_attach_function_params(name, func, args, returns, options)
+      mname = name
+      a2 = func
+      a3 = args
+      a4 = returns
+      a5 = options
+      cname, arg_types, ret_type, opts = if a4 && (a2.is_a?(String) || a2.is_a?(Symbol))
+          [a2, a3, a4, a5]
+        else
+          [mname.to_s, a2, a3, a4]
+        end
+      # Convert :foo to the native type
+      arg_types = arg_types.map { |e| find_type(e) }
+      options = {
+        convention: ffi_convention,
+        type_map: defined?(@ffi_typedefs) ? @ffi_typedefs : nil,
+        blocking: defined?(@blocking) && @blocking,
+        enums: defined?(@ffi_enums) ? @ffi_enums : nil,
+      }
+
+      @blocking = false
+      options.merge!(opts) if opts.is_a?(Hash)
+
+      [mname, cname, arg_types, ret_type, options]
+    end
+
+    def find_function_handle(cname, arg_types)
+      ffi_libraries.each do |lib|
+        begin
+          function_names(cname, arg_types).each do |fname|
+            fn = lib.find_function(fname)
+            return fn if fn
+          end
+        rescue LoadError
+        end
+      end
+
+      raise FFI::NotFoundError.new(cname.to_s, ffi_libraries.map(&:name))
+    end
+
+    def attach_function_handle(function_handle, mname, arg_types, ret_type, options)
+      invoker = if arg_types[-1] == FFI::NativeType::VARARGS
+          VariadicInvoker.new(function_handle, arg_types, find_type(ret_type), options)
+        else
+          Function.new(find_type(ret_type), arg_types, function_handle, options)
+        end
+      invoker.attach(self, mname.to_s)
+      invoker
+    end
+
     # Generic enum builder
     #  @param [Class] klass can be one of FFI::Enum or FFI::Bitmask
     #  @param args (see #enum or #bitmask)

--- a/lib/ffi/library.rb
+++ b/lib/ffi/library.rb
@@ -392,6 +392,7 @@ module FFI
         end
       # Convert :foo to the native type
       arg_types = arg_types.map { |e| find_type(e) }
+      ret_type = find_type(ret_type)
       options = {
         convention: ffi_convention,
         type_map: defined?(@ffi_typedefs) ? @ffi_typedefs : nil,
@@ -421,9 +422,9 @@ module FFI
 
     def attach_function_handle(function_handle, mname, arg_types, ret_type, options)
       invoker = if arg_types[-1] == FFI::NativeType::VARARGS
-          VariadicInvoker.new(function_handle, arg_types, find_type(ret_type), options)
+          VariadicInvoker.new(function_handle, arg_types, ret_type, options)
         else
-          Function.new(find_type(ret_type), arg_types, function_handle, options)
+          Function.new(ret_type, arg_types, function_handle, options)
         end
       invoker.attach(self, mname.to_s)
       invoker


### PR DESCRIPTION
Hi! Is there any chance this could get merged?

I’m developing a [gem](https://github.com/uvlad7/ffi-llvm-jit/pull/2) that extends `FFI::Library` and uses LLVM to generate JIT wrappers for attached native functions.

My goal is full compatibility with regular `FFI` (except for the return value of `attach_function`). At the moment, it fully supports numeric types, strings, and booleans (well, I haven’t handled `rbffi_save_errno` yet, but that can be implemented without explicit support from this gem).

To support pointers, buffers, and potentially structs passed by value, I need to reuse logic from FFI’s native implementation.

Unfortunately, integrating this directly into ffi isn’t practical, since my project depends on ruby-llvm, which itself relies on ffi.

While it’s technically possible to replicate the behavior of `getPointer` and `rbffi_Pointer_NewInstance`, it’s not straightforward - especially for `getPointer`. It would require calling back into Ruby, which would affect performance and introduce another potential source of behavioral differences.

I’ve kept the integration layer as thin as possible to avoid tight coupling. I also intentionally made the Ruby methods private and the C functions static to prevent other gems from depending on them.