### PR TITLE
Use libc allocator for Pointer and MemoryPointer-owned storage

### DIFF
--- a/ext/ffi_c/MemoryPointer.c
+++ b/ext/ffi_c/MemoryPointer.c
@@ -112,7 +112,11 @@ memptr_malloc(VALUE self, long size, long count, bool clear)
 
     msize = size * count;
 
-    p->storage = xmalloc(msize + 7);
+    /*
+     * MemoryPointer buffers may be handed off to native code that
+     * may later release them with libc free().
+     */
+    p->storage = malloc(msize + 7);
     if (p->storage == NULL) {
         rb_raise(rb_eNoMemError, "Failed to allocate memory size=%ld bytes", msize);
         return Qnil;
@@ -141,7 +145,8 @@ memptr_free(VALUE self)
 
     if (ptr->allocated) {
         if (ptr->storage != NULL) {
-            xfree(ptr->storage);
+            /* See memptr_malloc: storage is malloc()-backed. */
+            free(ptr->storage);
             ptr->storage = NULL;
         }
         ptr->allocated = false;
@@ -155,7 +160,8 @@ memptr_release(void *data)
 {
     Pointer *ptr = (Pointer *)data;
     if (ptr->autorelease && ptr->allocated && ptr->storage != NULL) {
-        xfree(ptr->storage);
+        /* See memptr_malloc: storage is malloc()-backed. */
+        free(ptr->storage);
         ptr->storage = NULL;
     }
     xfree(ptr);

--- a/ext/ffi_c/Pointer.c
+++ b/ext/ffi_c/Pointer.c
@@ -181,11 +181,13 @@ ptr_initialize_copy(VALUE self, VALUE other)
     }
 
     if (dst->storage != NULL) {
-        xfree(dst->storage);
+        /* Keep pair with malloc() used for pointer-owned storage. */
+        free(dst->storage);
         dst->storage = NULL;
     }
 
-    dst->storage = xmalloc(src->size + 7);
+    /* Pointer-owned storage is libc-backed for allocator symmetry. */
+    dst->storage = malloc(src->size + 7);
     if (dst->storage == NULL) {
         rb_raise(rb_eNoMemError, "failed to allocate memory size=%lu bytes", src->size);
         return Qnil;
@@ -406,7 +408,8 @@ ptr_free(VALUE self)
 
     if (ptr->allocated) {
         if (ptr->storage != NULL) {
-            xfree(ptr->storage);
+            /* Keep pair with malloc() used for pointer-owned storage. */
+            free(ptr->storage);
             ptr->storage = NULL;
         }
         ptr->allocated = false;
@@ -469,7 +472,8 @@ ptr_release(void *data)
 {
     Pointer *ptr = (Pointer *)data;
     if (ptr->autorelease && ptr->allocated && ptr->storage != NULL) {
-        xfree(ptr->storage);
+        /* Keep pair with malloc() used for pointer-owned storage. */
+        free(ptr->storage);
         ptr->storage = NULL;
     }
     xfree(ptr);

--- a/spec/ffi/dup_spec.rb
+++ b/spec/ffi/dup_spec.rb
@@ -34,6 +34,14 @@ describe "Pointer#dup" do
     # first char will be excised
     expect(p2.get_string(0)).to eq("est123")
   end
+
+  it "cloned pointer can be freed" do
+    p1 = FFI::MemoryPointer.new(:char, 1024)
+    p1.put_string(0, "test123")
+    p2 = p1[1].dup
+
+    expect { p2.free }.not_to raise_error
+  end
 end
 
 

--- a/spec/ffi/memorypointer_spec.rb
+++ b/spec/ffi/memorypointer_spec.rb
@@ -76,6 +76,36 @@ describe "MemoryPointer argument" do
     expect(p2.get_int(0)).not_to eql 0
   end
 end
+
+describe "MemoryPointer allocated memory ownership" do
+  module ForeignFree
+    extend FFI::Library
+    ffi_lib FFI::Platform::LIBC
+
+    attach_function :free, [:pointer], :void
+  end
+
+  it "can be released by libc free when created with from_string" do
+    ptr = MemoryPointer.from_string("ffi")
+    ptr.autorelease = false
+
+    expect { ForeignFree.free(ptr) }.not_to raise_error
+  end
+
+  it "can be freed via MemoryPointer#free" do
+    ptr = MemoryPointer.new(8)
+    expect { ptr.free }.not_to raise_error
+  end
+
+  it "can be duplicated and both instances can be freed" do
+    original = MemoryPointer.new(8)
+    copy = original.dup
+
+    expect { copy.free }.not_to raise_error
+    expect { original.free }.not_to raise_error
+  end
+end
+
 describe "MemoryPointer return value" do
   module Stdio
     extend FFI::Library


### PR DESCRIPTION
Pointer/MemoryPointer storage was previously allocated with xmalloc, so when native code calls libc free() we can hit allocator mismatch and abort on the latest development version of Ruby.

To make ownership-transfer workflows safe, this switches pointer-owned backing storage to malloc/free. This includes MemoryPointer and Pointer paths used by clone/dup, #free, and finalization.

The scope is still narrow to pointer-owned storage (not Buffer or other internal structures).

Example usage in the wild that can crash before this change:

1. Create C string pointer in sassc (via ffi)
   - SassC::Native.native_string
   - FFI::MemoryPointer.from_string(string) + autorelease = false
   - https://github.com/sass/sassc-ruby/blob/v2.4.0/lib/sassc/native.rb#L54-L58
2. Pass pointer into libsass data context
   - make_data_context calls sass_make_data_context
   - https://github.com/sass/sassc-ruby/blob/v2.4.0/lib/sassc/native/native_context_api.rb#L15-L18
3. Engine lifecycle
   - create context, compile, then ensure delete_data_context
   - https://github.com/sass/sassc-ruby/blob/v2.4.0/lib/sassc/engine.rb#L25-L26
   - https://github.com/sass/sassc-ruby/blob/v2.4.0/lib/sassc/engine.rb#L43
   - https://github.com/sass/sassc-ruby/blob/v2.4.0/lib/sassc/engine.rb#L63
4. ffi allocation side (from_string => xmalloc)
   - memptr_s_from_string constructs MemoryPointer
   - https://github.com/ffi/ffi/blob/v1.17.4/ext/ffi_c/MemoryPointer.c#L182-L188
   - constructor allocates backing storage with xmalloc
   - https://github.com/ffi/ffi/blob/v1.17.4/ext/ffi_c/MemoryPointer.c#L106-L117
5. libsass takes ownership and later frees with libc free
   - store incoming pointer: ctx->source_string = source_string
   - https://github.com/sass/libsass/blob/3.6.6/src/sass_context.cpp#L363-L376
   - free on teardown: free(ctx->source_string)
   - https://github.com/sass/libsass/blob/3.6.6/src/sass_context.cpp#L590-L596